### PR TITLE
Non-breaking UI refactor: flatten cards, unify spacing, themed scroll…

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -9,8 +9,7 @@
       indeterminate
       size="64"
     ></v-progress-circular>
-    <br />
-    {{ $t('loading') }}
+    <div class="text-no-wrap mt-2">{{ $t('loading') }}</div>
   </v-overlay>
   <Message />
   <router-view />
@@ -25,10 +24,3 @@ const loading:Ref = inject('loading')?? ref(false)
 // Change page title
 document.title = "S-UI " + document.location.hostname
 </script>
-
-<style>
-.v-overlay .v-list-item,
-.v-field__input {
-  direction: ltr;
-}
-</style>

--- a/src/components/Addr.vue
+++ b/src/components/Addr.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('out.addr')"
       hide-details
@@ -8,7 +8,7 @@
       v-model="addr.server">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('out.port')"
       hide-details
@@ -16,7 +16,7 @@
       required
       v-model.number="addr.server_port"></v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4" v-if="optionRemark">
+    <v-col cols="12" sm="6" lg="4" v-if="optionRemark">
       <v-text-field
       :label="$t('in.remark')"
       hide-details

--- a/src/components/Dial.vue
+++ b/src/components/Dial.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card :subtitle="$t('objects.dial')" style="background-color: inherit;">
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="optionDetour">
+      <v-col cols="12" sm="6" lg="4" v-if="optionDetour">
         <v-select
           hide-details
           :label="$t('dial.detourText')"
@@ -9,7 +9,7 @@
           v-model="dial.detour">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionBind">
+      <v-col cols="12" sm="6" lg="4" v-if="optionBind">
         <v-text-field
         :label="$t('dial.bindIf')"
         hide-details
@@ -17,24 +17,24 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="optionIPV4">
+      <v-col cols="12" sm="6" lg="4" v-if="optionIPV4">
         <v-text-field
         :label="$t('dial.bindIp4')"
         hide-details
         v-model="dial.inet4_bind_address"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionIPV6">
+      <v-col cols="12" sm="6" lg="4" v-if="optionIPV6">
         <v-text-field
         :label="$t('dial.bindIp6')"
         hide-details
         v-model="dial.inet6_bind_address"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionBindNoPort">
+      <v-col cols="12" sm="6" lg="4" v-if="optionBindNoPort">
         <v-switch v-model="dial.bind_address_no_port" color="primary" :label="$t('dial.bindNoPort')" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="optionRM">
+      <v-col cols="12" sm="6" lg="4" v-if="optionRM">
         <v-text-field
         label="Linux Routing Mark"
         hide-details
@@ -42,34 +42,34 @@
         min="0"
         v-model.number="routingMark"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionRA">
+      <v-col cols="12" sm="6" lg="4" v-if="optionRA">
         <v-switch v-model="dial.reuse_addr" color="primary" :label="$t('dial.reuseAddr')" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row v-if="optionTCP">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="dial.tcp_fast_open" color="primary" label="TCP Fast Open" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="dial.tcp_multi_path" color="primary" label="TCP Multi Path" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row v-if="optionTcpKeepAlive">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="dial.disable_tcp_keep_alive" color="primary" :label="$t('dial.disableTcpKeepAlive')" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="dial.tcp_keep_alive" :label="$t('dial.tcpKeepAlive')" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="dial.tcp_keep_alive_interval" :label="$t('dial.tcpKeepAliveInterval')" hide-details></v-text-field>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="optionUDP">
+      <v-col cols="12" sm="6" lg="4" v-if="optionUDP">
         <v-switch v-model="dial.udp_fragment" color="primary" label="UDP Fragment" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionCT">
+      <v-col cols="12" sm="6" lg="4" v-if="optionCT">
         <v-text-field
         :label="$t('dial.connTimeout')"
         hide-details
@@ -80,7 +80,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionDR">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('dial.domainResolver')"

--- a/src/components/DnsRule.vue
+++ b/src/components/DnsRule.vue
@@ -21,7 +21,7 @@
           hide-details
         ></v-combobox>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionIPver">
+      <v-col cols="12" sm="6" lg="4" v-if="optionIPver">
         <v-select
           hide-details
           :label="$t('rule.ipVer')"
@@ -41,7 +41,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionDomain">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="domainKeys"
@@ -75,7 +75,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionPort">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="portKeys"
@@ -97,7 +97,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionSrcIP">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="srcIPKeys"
@@ -107,7 +107,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionSrcPort">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="srcPortKeys"

--- a/src/components/Editor.vue
+++ b/src/components/Editor.vue
@@ -5,7 +5,7 @@
         {{ title }}
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
+      <v-card-text class="px-4 overflow-y-auto">
         <div class="code-editor">
           <div class="line-numbers">
             <span v-for="n in lineCount" :key="n">{{ n }}</span>

--- a/src/components/Headers.vue
+++ b/src/components/Headers.vue
@@ -8,7 +8,7 @@
         </v-chip>
       </v-card-subtitle>
       <v-row v-for="(header, index) in hdrs">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
             :label="$t('objects.key')"
             hide-details
@@ -16,7 +16,7 @@
             v-model="header.name">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
             :label="$t('objects.value')"
             hide-details

--- a/src/components/Listen.vue
+++ b/src/components/Listen.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card :subtitle="$t('objects.listen')">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('in.addr')"
         hide-details
@@ -9,7 +9,7 @@
         v-model="data.listen">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('in.port')"
         hide-details
@@ -21,7 +21,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="optionDetour">
+      <v-col cols="12" sm="6" lg="4" v-if="optionDetour">
         <v-select
         :label="$t('listen.detourText')"
         hide-details
@@ -31,18 +31,18 @@
       </v-col>
     </v-row>
     <v-row v-if="optionTCP">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.tcp_fast_open" color="primary" label="TCP Fast Open" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.tcp_multi_path" color="primary" label="TCP Multi Path" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row v-if="optionUDP">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.udp_fragment" color="primary" label="UDP Fragment" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         label="UDP NAT expiration"
         hide-details
@@ -53,13 +53,13 @@
       </v-col>
     </v-row>
     <v-row v-if="optionTcpKeepAlive">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.disable_tcp_keep_alive" color="primary" :label="$t('listen.disableTcpKeepAlive')" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.tcp_keep_alive" :label="$t('listen.tcpKeepAlive')" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.tcp_keep_alive_interval" :label="$t('listen.tcpKeepAliveInterval')" hide-details></v-text-field>
       </v-col>
     </v-row>

--- a/src/components/Main.vue
+++ b/src/components/Main.vue
@@ -13,9 +13,9 @@
         <v-col cols="auto">
           <v-dialog v-model="menu" :close-on-content-click="false" transition="scale-transition" max-width="800">
             <template v-slot:activator="{ props }">
-              <v-btn v-bind="props" hide-details variant="tonal" elevation="3">{{ $t('main.tiles') }} <v-icon icon="mdi-star-plus" /></v-btn>
+              <v-btn v-bind="props" hide-details variant="tonal">{{ $t('main.tiles') }} <v-icon icon="mdi-star-plus" /></v-btn>
             </template>
-            <v-card rounded="xl">
+            <v-card rounded="lg">
               <v-card-title>
                 <v-row>
                   <v-col>
@@ -26,50 +26,47 @@
                 </v-row>
               </v-card-title>
               <v-divider></v-divider>
-              <v-row v-for="items in menuItems" density="compact">
-                <v-col cols="12">
-                  <v-card :subtitle="items.title" variant="flat">
-                    <v-card-text>
-                      <v-row density="compact">
-                        <v-col cols="12" md="6" lg="3" v-for="item in items.value">
-                          <v-switch
-                          density="compact"
-                          v-model="reloadItems"
-                          :value="item.value"
-                          color="primary"
-                          :label="item.title"
-                          hide-details></v-switch>
-                        </v-col>
-                      </v-row>
-                    </v-card-text>
-                  </v-card>
-                </v-col>
-              </v-row>
+              <v-card-text>
+                <div v-for="items in menuItems" class="mb-2">
+                  <div class="text-subtitle-2 text-medium-emphasis mb-1">{{ items.title }}</div>
+                  <v-row density="compact">
+                    <v-col cols="12" md="6" lg="3" v-for="item in items.value">
+                      <v-switch
+                      density="compact"
+                      v-model="reloadItems"
+                      :value="item.value"
+                      color="primary"
+                      :label="item.title"
+                      hide-details></v-switch>
+                    </v-col>
+                  </v-row>
+                </div>
+              </v-card-text>
             </v-card>
           </v-dialog>
           <v-btn variant="tonal" hide-details 
-            style="margin-inline-start: 10px;" elevation="3"
+            class="ms-2"
             @click="backupModal.visible = true">{{ $t('main.backup.title') }}<v-icon icon="mdi-backup-restore" />
           </v-btn>
           <v-btn variant="tonal" hide-details
-            style="margin-inline-start: 10px;" elevation="3"
+            class="ms-2"
             @click="logModal.visible = true">{{ $t('basic.log.title') }} <v-icon icon="mdi-list-box-outline" />
           </v-btn>
           <v-btn variant="tonal" hide-details
-            style="margin-inline-start: 10px;" elevation="3"
+            class="ms-2"
             @click="usageStatsModal.visible = true">{{ $t('main.stats.title') }} <v-icon icon="mdi-chart-box-outline" />
           </v-btn>
         </v-col>
       </v-row>
       <v-row>
         <v-col cols="12" sm="6" md="3" v-for="i in reloadItems" :key="i">
-          <v-card class="rounded-lg" variant="outlined" height="210px" elevation="5">
+          <v-card class="rounded-lg" variant="outlined" height="210px">
             <v-card-title>
               {{ menuItems.flatMap(cat => cat.value).find(m => m.value == i)?.title }}
               <template v-if="i == 'i-sys'">
                 <v-icon icon="mdi-update" color="primary"
                   @click="reloadSys()" size="small" v-tooltip:top="$t('actions.update')"
-                  style="margin-inline-start: 10px;">
+                  class="ms-2">
                 </v-icon>
               </template>
               <template v-if="i == 'h-net'">
@@ -77,11 +74,11 @@
                   v-tooltip:top="'↓' + 
                   HumanReadable.sizeFormat(tilesData.net?.recv) + ' - ' + 
                   HumanReadable.sizeFormat(tilesData.net?.sent) + '↑'"
-                  style="margin-inline-start: 10px;">
+                  class="ms-2">
                 </v-icon>
               </template>
             </v-card-title>
-            <v-card-text style="padding: 0 16px;" align="center" justify="center">
+            <v-card-text class="px-4" align="center" justify="center">
               <Gauge :tilesData="tilesData" :type="i" v-if="i.charAt(0) == 'g'" />
               <History :tilesData="tilesData" :type="i" v-if="i.charAt(0) == 'h'" />
               <template v-if="i == 'i-sys'">

--- a/src/components/Multiplex.vue
+++ b/src/components/Multiplex.vue
@@ -1,12 +1,12 @@
 <template>
   <v-card :subtitle="$t('objects.multiplex')">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" :label="$t('mux.enable')" v-model="muxEnable" hide-details></v-switch>
       </v-col>
       <template v-if="muxEnable">
         <template v-if="direction=='out'">
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               hide-details
               :items="[ 'smux', 'yamux', 'h2mux']"
@@ -16,7 +16,7 @@
               v-model="mux.protocol">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field
             :label="$t('mux.maxConn')"
             hide-details
@@ -25,7 +25,7 @@
             v-model.number="max_connections">
             </v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field
             :label="$t('mux.minStr')"
             hide-details
@@ -34,7 +34,7 @@
             v-model.number="min_streams">
             </v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field
             :label="$t('mux.maxStr')"
             hide-details
@@ -44,16 +44,16 @@
             </v-text-field>
           </v-col>
         </template>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" :label="$t('mux.padding')" v-model="padding" hide-details></v-switch>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" :label="$t('mux.enableBrutal')" v-model="burtalEnable" hide-details></v-switch>
         </v-col>
       </template>
     </v-row>
     <v-row v-if="mux?.brutal?.enabled">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('stats.upload')"
         hide-details
@@ -62,7 +62,7 @@
         v-model.number="up_mbps">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('stats.download')"
         hide-details

--- a/src/components/OutJson.vue
+++ b/src/components/OutJson.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card :subtitle="$t('pages.basics')">
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="type == inTypes.SOCKS">
+      <v-col cols="12" sm="6" lg="4" v-if="type == inTypes.SOCKS">
         <v-select
           hide-details
           :items="['4','4a','5']"
@@ -9,20 +9,20 @@
           v-model="inData.out_json.version">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="needNetwork">
+      <v-col cols="12" sm="6" lg="4" v-if="needNetwork">
         <Network :data="inData.out_json" />
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="needUot">
+      <v-col cols="12" sm="6" lg="4" v-if="needUot">
         <UoT :data="inData.out_json" />
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="type == inTypes.HTTP">
+      <v-col cols="12" sm="6" lg="4" v-if="type == inTypes.HTTP">
         <v-text-field
         :label="$t('transport.path')"
         hide-details
         v-model="inData.out_json.path">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="type == inTypes.VMess || type == inTypes.VLESS">
+      <v-col cols="12" sm="6" lg="4" v-if="type == inTypes.VMess || type == inTypes.VLESS">
         <v-select
           hide-details
           :label="$t('types.vless.udpEnc')"
@@ -31,7 +31,7 @@
         </v-select>
       </v-col>
       <template v-if="type == inTypes.VMess">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-select
             hide-details
             :label="$t('types.vmess.security')"
@@ -39,14 +39,14 @@
             v-model="inData.out_json.security">
           </v-select>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch v-model="inData.out_json.global_padding" color="primary" :label="$t('types.vmess.globalPadding')" hide-details></v-switch>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch v-model="inData.out_json.authenticated_length" color="primary" :label="$t('types.vmess.authLen')" hide-details></v-switch>
         </v-col>
       </template>
-      <v-col cols="12" sm="6" md="4" v-if="type == inTypes.Hysteria">
+      <v-col cols="12" sm="6" lg="4" v-if="type == inTypes.Hysteria">
         <v-text-field
         label="Recv window"
         hide-details
@@ -56,7 +56,7 @@
         </v-text-field>
       </v-col>
       <template v-if="type == inTypes.TUIC">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-select
             hide-details
             label="UDP Relay Mode"
@@ -66,7 +66,7 @@
             v-model="inData.out_json.udp_relay_mode">
           </v-select>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" label="UDP Over Stream" v-model="inData.out_json.udp_over_stream" hide-details></v-switch>
         </v-col>
       </template>
@@ -78,7 +78,7 @@
           v-model="server_ports">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
           :label="$t('ruleset.interval')"
           type="number"

--- a/src/components/Rule.vue
+++ b/src/components/Rule.vue
@@ -29,7 +29,7 @@
           hide-details
         ></v-combobox>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionIPver">
+      <v-col cols="12" sm="6" lg="4" v-if="optionIPver">
         <v-select
           hide-details
           :label="$t('rule.ipVer')"
@@ -37,7 +37,7 @@
           v-model.number="rule.ip_version">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionNetwork">
+      <v-col cols="12" sm="6" lg="4" v-if="optionNetwork">
         <v-select
           hide-details
           multiple
@@ -59,7 +59,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionDomain">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="domainKeys"
@@ -127,7 +127,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionPort">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="portKeys"
@@ -159,7 +159,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionSrcIP">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="srcIPKeys"
@@ -183,7 +183,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionSrcPort">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="srcPortKeys"
@@ -227,7 +227,7 @@
       </v-col>
     </v-row>
     <v-row v-if="optionInterface">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="interfaceKeys"

--- a/src/components/SimpleDNS.vue
+++ b/src/components/SimpleDNS.vue
@@ -1,6 +1,6 @@
 <template>
   <v-row density="compact">
-    <v-col cols="12" class="v-card-subtitle" style="margin-top: -5px;">{{ label }}</v-col>
+    <v-col cols="12" class="text-subtitle-2 text-medium-emphasis">{{ label }}</v-col>
     <v-col :cols="data.type == 'local' ? 12 : 4">
       <v-select
         hide-details

--- a/src/components/Transport.vue
+++ b/src/components/Transport.vue
@@ -1,10 +1,10 @@
 <template>
     <v-card :subtitle="$t('objects.transport')">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" :label="$t('transport.enable')" v-model="tpEnable" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="tpEnable">
+      <v-col cols="12" sm="6" lg="4" v-if="tpEnable">
         <v-select
           hide-details
           :label="$t('type')"

--- a/src/components/Users.vue
+++ b/src/components/Users.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card :subtitle="$t('pages.clients')">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select v-model="data.model" :items="initUsersModels" @update:model-value="data.values = []" hide-details></v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.model == 'group'">
+      <v-col cols="12" sm="6" lg="4" v-if="data.model == 'group'">
         <v-select v-model="data.values" multiple chips :items="groupNames" :label="$t('client.group')" hide-details></v-select>
       </v-col>
       <v-col cols="12" sm="8" v-if="data.model == 'client'">

--- a/src/components/WgPeer.vue
+++ b/src/components/WgPeer.vue
@@ -16,14 +16,14 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('out.addr')"
       hide-details
       v-model="address">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('out.port')"
       type="number"
@@ -32,7 +32,7 @@
       v-model.number="port">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       label="KeepAlive"
       type="number"

--- a/src/components/protocols/AnyTls.vue
+++ b/src/components/protocols/AnyTls.vue
@@ -19,7 +19,7 @@
         v-model="data.password">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.anytls.idleInterval')"
         type="number"
@@ -29,7 +29,7 @@
         v-model.number="idleInterval">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.anytls.idleTimeout')"
         type="number"
@@ -39,7 +39,7 @@
         v-model.number="idleTimeout">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.anytls.minIdle')"
         type="number"

--- a/src/components/protocols/Direct.vue
+++ b/src/components/protocols/Direct.vue
@@ -1,17 +1,17 @@
 <template>
   <v-card subtitle="Direct">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="data" />
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.direct.overrideAddr')"
         hide-details
         v-model="data.override_address">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.direct.overridePort')"
         type="number"

--- a/src/components/protocols/Http.vue
+++ b/src/components/protocols/Http.vue
@@ -1,21 +1,21 @@
 <template>
   <v-card subtitle="HTTP">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.un')"
         hide-details
         v-model="username">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.pw')"
         hide-details
         v-model="password">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('transport.path')"
         hide-details

--- a/src/components/protocols/Hysteria.vue
+++ b/src/components/protocols/Hysteria.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card subtitle="Hysteria">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('stats.upload')"
         hide-details
@@ -10,7 +10,7 @@
         v-model.number="up_mbps">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('stats.download')"
         hide-details
@@ -22,14 +22,14 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
        <v-text-field
        :label="$t('types.hy.obfs')"
         hide-details
         v-model="data.obfs">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="direction=='out'">
+      <v-col cols="12" sm="6" lg="4" v-if="direction=='out'">
         <v-text-field
         :label="$t('types.hy.auth')"
         hide-details
@@ -38,15 +38,15 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="direction=='out'">
+      <v-col cols="12" sm="6" lg="4" v-if="direction=='out'">
         <Network :data="data" />
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.disable_mtu_discovery" color="primary" label="Disable MTU discovery" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="data.recv_window_conn != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.recv_window_conn != undefined">
         <v-text-field
         label="Recv window conn"
         hide-details
@@ -55,7 +55,7 @@
         v-model.number="data.recv_window_conn">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.recv_window != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.recv_window != undefined">
         <v-text-field
         label="Recv window"
         hide-details
@@ -64,7 +64,7 @@
         v-model.number="data.recv_window">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.recv_window_client != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.recv_window_client != undefined">
         <v-text-field
         label="Recv window client"
         hide-details
@@ -73,7 +73,7 @@
         v-model.number="data.recv_window_client">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.max_conn_client != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.max_conn_client != undefined">
         <v-text-field
         label="Max conn client"
         hide-details

--- a/src/components/protocols/Hysteria2.vue
+++ b/src/components/protocols/Hysteria2.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card subtitle="Hysteria2">
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="direction == 'in'">
+      <v-col cols="12" sm="6" lg="4" v-if="direction == 'in'">
         <v-switch v-model="data.ignore_client_bandwidth" color="primary" :label="$t('types.hy.ignoreBw')" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="!data.ignore_client_bandwidth">
+      <v-col cols="12" sm="6" lg="4" v-if="!data.ignore_client_bandwidth">
         <v-text-field
         :label="$t('stats.upload')"
         hide-details
@@ -14,7 +14,7 @@
         v-model.number="up_mbps">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="!data.ignore_client_bandwidth">
+      <v-col cols="12" sm="6" lg="4" v-if="!data.ignore_client_bandwidth">
         <v-text-field
         :label="$t('stats.download')"
         hide-details
@@ -26,7 +26,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="data.obfs != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.obfs != undefined">
       <v-text-field
         :label="$t('types.hy.obfs')"
         hide-details
@@ -37,7 +37,7 @@
     <template v-if="direction == 'in'">
       <v-card subtitle="Hysteria2 Masquerade" v-if="data.masquerade != undefined">
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select v-model="masqueradeType" hide-details :label="$t('type')" :items="masqTypes"></v-select>
           </v-col>
           <v-col cols="12" sm="8" v-if="masqueradeType == ''">
@@ -56,7 +56,7 @@
             hide-details>
             </v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4" v-if="masqueradeType == 'string'">
+          <v-col cols="12" sm="6" lg="4" v-if="masqueradeType == 'string'">
             <v-text-field
             label="HTTP Code"
             type="number"
@@ -76,7 +76,7 @@
             hide-details>
             </v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-switch
             label="Rewrite Host"
             v-model="data.masquerade.rewrite_host"
@@ -101,14 +101,14 @@
     </template>
     <template v-else>
       <v-row>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
           :label="$t('types.pw')"
           hide-details
           v-model="data.password">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <Network :data="data" />
         </v-col>
         <v-col cols="12" sm="8" v-if="optionMPort">
@@ -117,7 +117,7 @@
             v-model="server_ports">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="optionMPort">
+        <v-col cols="12" sm="6" lg="4" v-if="optionMPort">
           <v-text-field
             :label="$t('ruleset.interval')"
             type="number"

--- a/src/components/protocols/Naive.vue
+++ b/src/components/protocols/Naive.vue
@@ -4,10 +4,10 @@
     <!-- Inbound -->
     <template v-if="direction === 'in'">
       <v-row>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <Network :data="data" />
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-select
             hide-details
             :label="$t('types.naive.quicCongestion')"
@@ -22,14 +22,14 @@
     <!-- Outbound -->
     <template v-if="['out', 'out_json'].includes(direction)">
       <v-row v-if="direction === 'out'">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
             :label="$t('types.un')"
             hide-details
             v-model="data.username">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
             :label="$t('types.pw')"
             hide-details
@@ -39,7 +39,7 @@
         </v-col>
       </v-row>
       <v-row>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
             :label="$t('types.naive.insecureConcurrency')"
             type="number"
@@ -48,15 +48,15 @@
             v-model.number="insecure_concurrency">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch v-model="udpOverTcp" color="primary" :label="$t('types.naive.udpOverTcp')" hide-details></v-switch>
         </v-col>
       </v-row>
       <v-row v-if="direction === 'out'">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch v-model="data.quic" color="primary" :label="$t('types.naive.quic')" hide-details></v-switch>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="data.quic">
+        <v-col cols="12" sm="6" lg="4" v-if="data.quic">
           <v-select
             hide-details
             :label="$t('types.naive.quicCongestion')"

--- a/src/components/protocols/OutShadowTls.vue
+++ b/src/components/protocols/OutShadowTls.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card subtitle="ShadowTls">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="[1,2,3]"
@@ -9,7 +9,7 @@
           v-model="version">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.version > 1">
+      <v-col cols="12" sm="6" lg="4" v-if="data.version > 1">
         <v-text-field
         :label="$t('types.pw')"
         hide-details

--- a/src/components/protocols/Selector.vue
+++ b/src/components/protocols/Selector.vue
@@ -12,7 +12,7 @@
           hide-details
         ></v-combobox>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-combobox
           v-model="data.default"
           :items="data.outbounds"

--- a/src/components/protocols/ShadowTls.vue
+++ b/src/components/protocols/ShadowTls.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card subtitle="ShadowTls">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="[1,2,3]"
@@ -10,26 +10,26 @@
           v-model="version">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.password != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.password != undefined">
         <v-text-field
         :label="$t('types.pw')"
         hide-details
         v-model="data.password">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="Inbound.wildcard_sni != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="Inbound.wildcard_sni != undefined">
         <v-select label="Wildcard SNI" :items="['off', 'authed', 'all']" clearable v-model="Inbound.wildcard_sni"></v-select>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.shdwTls.hs')"
         hide-details
         v-model="Inbound.handshake.server">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('out.port')"
         type="number"
@@ -41,7 +41,7 @@
     </v-row>
     <Dial :dial="Inbound.handshake" />
     <v-row v-if="Inbound.handshake_for_server_name != undefined">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.shdwTls.addHS')"
         hide-details
@@ -63,7 +63,7 @@
       v-for="(value, key) in Inbound.handshake_for_server_name"
       border
       density="compact"
-      style="margin: 5px;"
+      class="ma-1"
       color="background">
       <v-card-title>
         <v-row>
@@ -74,14 +74,14 @@
         </v-row>
       </v-card-title>
       <v-row>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
           :label="$t('types.shdwTls.hs')"
           hide-details
           v-model="value.server">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
           :label="$t('out.port')"
           type="number"

--- a/src/components/protocols/Shadowsocks.vue
+++ b/src/components/protocols/Shadowsocks.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card subtitle="Shadowsocks">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('in.ssMethod')"
@@ -10,13 +10,13 @@
           v-model="data.method">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="data" />
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="direction == 'out'">
+      <v-col cols="12" sm="6" lg="4" v-if="direction == 'out'">
         <UoT :data="data" />
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="direction == 'in'">
+      <v-col cols="12" sm="6" lg="4" v-if="direction == 'in'">
         <v-switch
           v-model="data.managed"
           color="primary"

--- a/src/components/protocols/Socks.vue
+++ b/src/components/protocols/Socks.vue
@@ -1,14 +1,14 @@
 <template>
   <v-card subtitle="SOCKS">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.un')"
         hide-details
         v-model="username">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.pw')"
         hide-details
@@ -17,7 +17,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :items="['4','4a','5']"
@@ -25,10 +25,10 @@
           v-model="data.version">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="data" />
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <UoT :data="data" />
       </v-col>
     </v-row>

--- a/src/components/protocols/Ssh.vue
+++ b/src/components/protocols/Ssh.vue
@@ -48,10 +48,10 @@
       </template>
       <template v-else>
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="data.user" :label="$t('types.un')" hide-details></v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="data.password" :label="$t('types.pw')" hide-details></v-text-field>
           </v-col>
         </v-row>
@@ -66,10 +66,10 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="data.host_key_algorithms != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.host_key_algorithms != undefined">
         <v-text-field v-model="algorithms" :label="$t('types.ssh.algorithm') + ' ' + $t('commaSeparated')" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.client_version != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.client_version != undefined">
         <v-text-field v-model="data.client_version" :label="$t('types.ssh.clientVer')" hide-details></v-text-field>
       </v-col>
     </v-row>

--- a/src/components/protocols/TProxy.vue
+++ b/src/components/protocols/TProxy.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card subtitle="TProxy">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="inbound" />
       </v-col>
     </v-row>

--- a/src/components/protocols/Tailscale.vue
+++ b/src/components/protocols/Tailscale.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card subtitle="Talescale">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" v-model="data.ephemeral" :label="$t('types.ts.ephemeral')"></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" v-model="data.accept_routes" :label="$t('types.ts.acceptRoutes')"></v-switch>
       </v-col>
     </v-row>
@@ -24,23 +24,23 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="optionHostname">
+      <v-col cols="12" sm="6" lg="4" v-if="optionHostname">
         <v-text-field v-model="data.hostname" :label="$t('types.ts.hostname')"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionUdpTimeout">
+      <v-col cols="12" sm="6" lg="4" v-if="optionUdpTimeout">
         <v-text-field type="number" v-model.number="udpTimeout" min="1" :suffix="$t('date.s')" :label="$t('types.ts.udpTimeout')"></v-text-field>
       </v-col>
     </v-row>
     <v-row v-if="optionExitNode">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.exit_node" :label="$t('types.ts.exitNode')"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" v-model="data.exit_node_allow_lan_access" :label="$t('types.ts.allowLanAccess')"></v-switch>
       </v-col>
     </v-row>
     <v-row v-if="optionRelay">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model.number="data.relay_server_port" type="number" min="0" :label="$t('types.ts.relayServerPort')" hide-details></v-text-field>
       </v-col>
       <v-col cols="12" sm="8">
@@ -48,13 +48,13 @@
       </v-col>
     </v-row>
     <v-row v-if="optionSysIf">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" v-model="data.system_interface" :label="$t('types.ts.systemInterface')"></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.system_interface">
+      <v-col cols="12" sm="6" lg="4" v-if="data.system_interface">
         <v-text-field v-model="data.system_interface_name" :label="$t('types.ts.sysIfName')" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.system_interface">
+      <v-col cols="12" sm="6" lg="4" v-if="data.system_interface">
         <v-text-field v-model.number="data.system_interface_mtu" type="number" min="0" :label="$t('types.ts.sysIfMtu')" hide-details></v-text-field>
       </v-col>
     </v-row>
@@ -62,7 +62,7 @@
       <v-col cols="12" sm="8">
         <v-text-field v-model="advertise_routes" :label="$t('types.ts.advRoutes') + ' ' + $t('commaSeparated')"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" v-model="data.advertise_exit_node" :label="$t('types.ts.advExitNode')"></v-switch>
       </v-col>
     </v-row>

--- a/src/components/protocols/Tor.vue
+++ b/src/components/protocols/Tor.vue
@@ -1,26 +1,26 @@
 <template>
   <v-card subtitle="Tor">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.executable_path" :label="$t('types.tor.execPath')" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.data_directory" :label="$t('types.tor.dataDir')" hide-details></v-text-field>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="extra_args" :label="$t('types.tor.extArgs') + ' ' + $t('commaSeparated')" hide-details></v-text-field>
       </v-col>
     </v-row>
-    <div class="v-card-subtitle" style="margin: 10px;">Torrc
+    <div class="text-subtitle-2 text-medium-emphasis ma-2">Torrc
       <v-chip color="primary" density="compact" variant="elevated" @click="add_torrc_option"><v-icon icon="mdi-plus" /></v-chip>
     </div>
     <v-row v-for="(torrc, index) in torrc_options">
       <v-col cols="auto" align-self="center" justify-self="center">
         <v-icon @click="del_torrc_option(index)" color="error" icon="mdi-delete" />
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
           :label="$t('objects.key')"
           hide-details
@@ -28,7 +28,7 @@
           v-model="torrc.name">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
           :label="$t('objects.value')"
           hide-details

--- a/src/components/protocols/Trojan.vue
+++ b/src/components/protocols/Trojan.vue
@@ -1,10 +1,10 @@
 <template>
   <v-card subtitle="Trojan">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.password" :label="$t('types.pw')" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="data" />
       </v-col>
     </v-row>

--- a/src/components/protocols/Tuic.vue
+++ b/src/components/protocols/Tuic.vue
@@ -4,13 +4,13 @@
       <v-col cols="12" sm="6">
         <v-text-field v-model="data.uuid" label="UUID" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.password" :label="$t('types.pw')" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="data" />
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           label="UDP Relay Mode"
@@ -20,12 +20,12 @@
           v-model="data.udp_relay_mode">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" label="UDP Over Stream" v-model="data.udp_over_stream" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('types.tuic.congControl')"
@@ -33,12 +33,12 @@
           v-model="data.congestion_control">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" label="Zero-RTT Handshake" v-model="data.zero_rtt_handshake" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="direction == 'in'">
+      <v-col cols="12" sm="6" lg="4" v-if="direction == 'in'">
         <v-text-field
         :label="$t('types.tuic.authTimeout')"
         hide-details
@@ -48,7 +48,7 @@
         v-model.number="auth_timeout">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
         :label="$t('types.tuic.hb')"
         hide-details

--- a/src/components/protocols/Tun.vue
+++ b/src/components/protocols/Tun.vue
@@ -6,15 +6,15 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field v-model="data.interface_name" :label="$t('types.tun.ifName')" placeholder="tun0" hide-details clearable @click:clear="delete data.interface_name"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field type="number" v-model.number="data.mtu" label="MTU" hide-details></v-text-field>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
           type="number"
           v-model.number="udpTimeout"
@@ -24,7 +24,7 @@
           hide-details>
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           v-model="data.stack"
           label="Stack"
@@ -32,24 +32,24 @@
           hide-details
         ></v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.endpoint_independent_nat" color="primary" label="Independent NAT" hide-details></v-switch>
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="autoRoute" color="primary" label="Auto Route" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="autoRoute">
+      <v-col cols="12" sm="6" lg="4" v-if="autoRoute">
         <v-switch v-model="data.auto_redirect" color="primary" label="Auto Redirect" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="autoRoute">
+      <v-col cols="12" sm="6" lg="4" v-if="autoRoute">
         <v-switch v-model="data.strict_route" color="primary" label="Strict Route" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="autoRoute && data.auto_redirect">
+      <v-col cols="12" sm="6" lg="4" v-if="autoRoute && data.auto_redirect">
         <v-switch v-model="data.exclude_mptcp" color="primary" :label="$t('types.tun.excludeMptcp')" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="autoRoute && data.auto_redirect">
+      <v-col cols="12" sm="6" lg="4" v-if="autoRoute && data.auto_redirect">
         <v-text-field
           type="number"
           v-model.number="fallbackRuleIndex"

--- a/src/components/protocols/UrlTest.vue
+++ b/src/components/protocols/UrlTest.vue
@@ -18,7 +18,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="optionInterval">
+      <v-col cols="12" sm="6" lg="4" v-if="optionInterval">
         <v-text-field
         :label="$t('types.lb.interval')"
         hide-details
@@ -27,7 +27,7 @@
         :suffix="$t('date.s')"
         v-model.number="interval"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionTolerance">
+      <v-col cols="12" sm="6" lg="4" v-if="optionTolerance">
         <v-text-field
         :label="$t('types.lb.tolerance')"
         hide-details
@@ -36,7 +36,7 @@
         :suffix="$t('date.ms')"
         v-model.number="tolerance"></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="optionIdle">
+      <v-col cols="12" sm="6" lg="4" v-if="optionIdle">
         <v-text-field
         :label="$t('transport.idleTimeout')"
         hide-details

--- a/src/components/protocols/Vless.vue
+++ b/src/components/protocols/Vless.vue
@@ -4,7 +4,7 @@
       <v-col cols="12" sm="6">
         <v-text-field v-model="data.uuid" label="UUID" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('types.vless.flow')"
@@ -14,7 +14,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('types.vless.udpEnc')"
@@ -22,7 +22,7 @@
           v-model="packet_encoding">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="data" />
       </v-col>
     </v-row>

--- a/src/components/protocols/Vmess.vue
+++ b/src/components/protocols/Vmess.vue
@@ -4,7 +4,7 @@
       <v-col cols="12" sm="6">
         <v-text-field v-model="data.uuid" label="UUID" hide-details></v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
           label="Alter ID"
           hide-details
@@ -15,7 +15,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('types.vmess.security')"
@@ -23,7 +23,7 @@
           v-model="data.security">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('types.vless.udpEnc')"
@@ -31,13 +31,13 @@
           v-model="packet_encoding">
         </v-select>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <Network :data="data" />
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.global_padding" color="primary" :label="$t('types.vmess.globalPadding')" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.authenticated_length" color="primary" :label="$t('types.vmess.authLen')" hide-details></v-switch>
       </v-col>
     </v-row>

--- a/src/components/protocols/Warp.vue
+++ b/src/components/protocols/Warp.vue
@@ -39,7 +39,7 @@
               v-model="data.peers[0].address">
             </v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field
               :label="$t('out.port')"
               hide-details
@@ -68,7 +68,7 @@
       </v-card>
     </template>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="data.udp_timeout != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.udp_timeout != undefined">
         <v-text-field
           label="UDP Timeout"
           hide-details
@@ -78,7 +78,7 @@
           v-model.number="udp_timeout">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.workers != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.workers != undefined">
         <v-text-field
         :label="$t('types.wg.worker')"
           hide-details
@@ -87,7 +87,7 @@
           v-model.number="data.workers">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.mtu != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.mtu != undefined">
         <v-text-field
           label="MTU"
           hide-details
@@ -98,10 +98,10 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.system" color="primary" :label="$t('types.wg.sysIf')" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.system">
+      <v-col cols="12" sm="6" lg="4" v-if="data.system">
         <v-text-field
           :label="$t('types.wg.ifName')"
           hide-details

--- a/src/components/protocols/Wireguard.vue
+++ b/src/components/protocols/Wireguard.vue
@@ -25,7 +25,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
           :label="$t('in.port')"
           hide-details
@@ -34,7 +34,7 @@
           v-model.number="data.listen_port">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.udp_timeout != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.udp_timeout != undefined">
         <v-text-field
           label="UDP Timeout"
           hide-details
@@ -46,7 +46,7 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4" v-if="data.workers != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.workers != undefined">
         <v-text-field
         :label="$t('types.wg.worker')"
           hide-details
@@ -55,7 +55,7 @@
           v-model.number="data.workers">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.mtu != undefined">
+      <v-col cols="12" sm="6" lg="4" v-if="data.mtu != undefined">
         <v-text-field
           label="MTU"
           hide-details
@@ -74,10 +74,10 @@
       </v-col>
     </v-row>
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch v-model="data.system" color="primary" :label="$t('types.wg.sysIf')" hide-details></v-switch>
       </v-col>
-      <v-col cols="12" sm="6" md="4" v-if="data.system">
+      <v-col cols="12" sm="6" lg="4" v-if="data.system">
         <v-text-field
           :label="$t('types.wg.ifName')"
           hide-details
@@ -113,7 +113,7 @@
       <v-chip color="primary" density="compact" variant="elevated" @click="addPeer"><v-icon icon="mdi-plus" /></v-chip>
     </v-card-subtitle>
     <template v-for="(p, index) in data.peers">
-      <v-card style="margin-top: 1rem;">
+      <v-card class="mt-2 border" rounded="lg">
         <v-card-subtitle>
           {{ $t('types.wg.peer') + ' ' + (Number(index)+1) }} <v-icon color="error" icon="mdi-delete" @click="delPeer(Number(index))" />
         </v-card-subtitle>

--- a/src/components/services/Ccm.vue
+++ b/src/components/services/Ccm.vue
@@ -28,7 +28,7 @@
       {{ $t('types.ccm.users') }}
       <v-chip color="primary" density="compact" variant="elevated" @click="addUser"><v-icon icon="mdi-plus" /></v-chip>
     </v-card-title>
-    <v-card v-for="(user, index) in (data.users || [])" :key="index" class="border" style="margin: 4px; padding: 8px;" rounded="xl">
+    <v-card v-for="(user, index) in (data.users || [])" :key="index" class="border ma-1 pa-2" rounded="lg">
       <v-row>
         <v-col cols="auto" align-self="center">
           <v-icon @click="delUser(index)" color="error" icon="mdi-delete" />

--- a/src/components/services/Derp.vue
+++ b/src/components/services/Derp.vue
@@ -39,7 +39,7 @@
           </v-col>
         </v-row>
       </v-card-title>
-      <v-card v-for="clientUrl, index in data.verify_client_url" :key="index" class="border" style="padding: 8px;" rounded="xl">
+      <v-card v-for="clientUrl, index in data.verify_client_url" :key="index" class="border pa-2" rounded="lg">
         <v-row>
           <v-col cols="auto" align-self="center" justify-self="center">
             <v-icon @click="data.verify_client_url.splice(index, 1)" color="error" icon="mdi-delete" />
@@ -64,21 +64,21 @@
           </v-col>
         </v-row>
       </v-card-title>
-      <v-card v-for="mesh, index in data.mesh_with" :key="index" class="border" style="padding: 8px;" rounded="xl">
+      <v-card v-for="mesh, index in data.mesh_with" :key="index" class="border pa-2" rounded="lg">
         <v-row>
           <v-col cols="auto" align-self="center" justify-self="center">
             <v-icon @click="data.mesh_with.splice(index, 1)" color="error" icon="mdi-delete" />
           </v-col>
           <v-col cols="11">
             <v-row>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-text-field
                 :label="$t('out.addr')"
                 hide-details
                 v-model="mesh.server">
                 </v-text-field>
               </v-col>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-text-field
                 :label="$t('out.port')"
                 hide-details
@@ -86,7 +86,7 @@
                 v-model.number="mesh.server_port">
                 </v-text-field>
               </v-col>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-text-field
                 :label="$t('transport.host')"
                 hide-details
@@ -136,7 +136,7 @@
       </v-row>
     </template>
     <template v-if="optionStun">
-      <v-card :title="$t('types.derp.stun')" class="border" style="padding: 8px;" rounded="xl">
+      <v-card :title="$t('types.derp.stun')" class="border pa-2" rounded="lg">
         <Listen :data="data.stun" :inTags="inTags" />
       </v-card>
     </template>

--- a/src/components/services/Ocm.vue
+++ b/src/components/services/Ocm.vue
@@ -28,7 +28,7 @@
       {{ $t('types.ocm.users') }}
       <v-chip color="primary" density="compact" variant="elevated" @click="addUser"><v-icon icon="mdi-plus" /></v-chip>
     </v-card-title>
-    <v-card v-for="(user, index) in (data.users || [])" :key="index" class="border" style="margin: 4px; padding: 8px;" rounded="xl">
+    <v-card v-for="(user, index) in (data.users || [])" :key="index" class="border ma-1 pa-2" rounded="lg">
       <v-row>
         <v-col cols="auto" align-self="center">
           <v-icon @click="delUser(index)" color="error" icon="mdi-delete" />

--- a/src/components/services/SSMAPI.vue
+++ b/src/components/services/SSMAPI.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-card style="padding: 8px;" rounded="xl" class="border">
+  <v-card class="border pa-2" rounded="lg">
     <v-card-subtitle>Shadowsocks API
       <v-chip color="primary" density="compact" variant="elevated" @click="add_server"><v-icon icon="mdi-plus" /></v-chip>
     </v-card-subtitle>
@@ -7,7 +7,7 @@
       <v-col cols="auto" align-self="center" justify-self="center">
         <v-icon @click="del_server(index)" color="error" icon="mdi-delete" />
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-text-field
           :label="$t('transport.path')"
           hide-details
@@ -15,7 +15,7 @@
           v-model="server.name">
         </v-text-field>
       </v-col>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           :label="$t('objects.inbound')"
           hide-details

--- a/src/components/tls/Acme.vue
+++ b/src/components/tls/Acme.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-card subtitle="ACME" style="background-color: inherit;">
+  <v-card subtitle="ACME">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" :label="$t('enable')" v-model="enabled" hide-details></v-switch>
       </v-col>
       <v-col cols="12" md="8" v-if="enabled">
@@ -14,14 +14,14 @@
     </v-row>
     <template v-if="enabled">
       <v-row>
-        <v-col cols="12" sm="6" md="4" v-if="optionDir">
+        <v-col cols="12" sm="6" lg="4" v-if="optionDir">
           <v-text-field
             :label="$t('tls.acme.dataDir')"
             hide-details
             v-model="acme.data_directory">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="optionDefault">
+        <v-col cols="12" sm="6" lg="4" v-if="optionDefault">
           <v-combobox
             v-model="acme.default_server_name"
             :items="acme.domain"
@@ -29,7 +29,7 @@
             hide-details
           ></v-combobox>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="optionEmail">
+        <v-col cols="12" sm="6" lg="4" v-if="optionEmail">
           <v-text-field
             :label="$t('email')"
             hide-details
@@ -38,15 +38,15 @@
         </v-col>
       </v-row>
       <v-row v-if="optionChallenge">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" :label="$t('tls.acme.httpChallenge')" v-model="acme.disable_http_challenge" hide-details></v-switch>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" :label="$t('tls.acme.tlsChallenge')" v-model="acme.disable_tls_alpn_challenge" hide-details></v-switch>
         </v-col>
       </v-row>
       <v-row v-if="optionPorts">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
           :label="$t('tls.acme.altHport')"
           hide-details
@@ -56,7 +56,7 @@
           v-model.number="acme.alternative_http_port">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
           :label="$t('tls.acme.altTport')"
           hide-details
@@ -68,7 +68,7 @@
         </v-col>
       </v-row>
       <v-row v-if="optionProvider">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-select
             v-model="caProvider"
             :items="providerList"
@@ -85,14 +85,14 @@
         </v-col>
       </v-row>
       <v-row v-if="acme.external_account != undefined">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
           label="Key ID"
           hide-details
           v-model="acme.external_account.key_id">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-text-field
           label="MAC Key"
           hide-details
@@ -101,7 +101,7 @@
         </v-col>
       </v-row>
       <v-row v-if="acme.dns01_challenge != undefined">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-select
           :label="$t('tls.acme.dns01Provider')"
           hide-details
@@ -110,7 +110,7 @@
           v-model="acme.dns01_challenge.provider">
           </v-select>
         </v-col>
-        <v-col cols="12" sm="6" md="4"
+        <v-col cols="12" sm="6" lg="4"
         v-for="item in dnsProviders.filter(d => d.provider == acme.dns01_challenge?.provider)[0]?.params"
         :key="item">
           <v-text-field

--- a/src/components/tls/Ech.vue
+++ b/src/components/tls/Ech.vue
@@ -1,7 +1,7 @@
 <template>
-  <v-card subtitle="ECH" style="background-color: inherit;">
+  <v-card subtitle="ECH">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" :label="$t('enable')" v-model="enabled" hide-details></v-switch>
       </v-col>
     </v-row>

--- a/src/components/tls/InTLS.vue
+++ b/src/components/tls/InTLS.vue
@@ -1,7 +1,7 @@
 <template>
   <v-card :subtitle="$t('objects.tls')">
     <v-row>
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-select
           hide-details
           :label="$t('template')"

--- a/src/components/tls/OutTLS.vue
+++ b/src/components/tls/OutTLS.vue
@@ -1,16 +1,16 @@
 <template>
   <v-card :subtitle="$t('objects.tls')">
     <v-row v-if="tlsOptional">
-      <v-col cols="12" sm="6" md="4">
+      <v-col cols="12" sm="6" lg="4">
         <v-switch color="primary" :label="$t('tls.enable')" v-model="tlsEnable" hide-details></v-switch>
       </v-col>
     </v-row>
     <template v-if="tls.enabled">
       <v-row>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" :label="$t('tls.disableSni')" v-model="disable_sni" hide-details></v-switch>
         </v-col>
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" :label="$t('tls.insecure')" v-model="insecure" hide-details></v-switch>
         </v-col>
       </v-row>
@@ -52,14 +52,14 @@
         </v-row>
       </template>
       <v-row>
-        <v-col cols="12" sm="6" md="4" v-if="tls.server_name != undefined">
+        <v-col cols="12" sm="6" lg="4" v-if="tls.server_name != undefined">
           <v-text-field
             label="SNI"
             hide-details
             v-model="tls.server_name">
           </v-text-field>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="tls.alpn">
+        <v-col cols="12" sm="6" lg="4" v-if="tls.alpn">
           <v-select
             hide-details
             label="ALPN"
@@ -70,7 +70,7 @@
         </v-col>
       </v-row>
       <v-row>
-        <v-col cols="12" sm="6" md="4" v-if="tls.min_version">
+        <v-col cols="12" sm="6" lg="4" v-if="tls.min_version">
           <v-select
             hide-details
             :label="$t('tls.minVer')"
@@ -78,7 +78,7 @@
             v-model="tls.min_version">
           </v-select>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="tls.max_version">
+        <v-col cols="12" sm="6" lg="4" v-if="tls.max_version">
           <v-select
             hide-details
             :label="$t('tls.maxVer')"
@@ -126,7 +126,7 @@
       </v-row>
       <template v-if="tls.ech != undefined">
         <v-row>
-          <v-col class="v-card-subtitle">ECH</v-col>
+          <v-col class="text-subtitle-2 text-medium-emphasis">ECH</v-col>
         </v-row>
         <v-row>
           <v-col cols="auto">
@@ -181,13 +181,13 @@
         </v-row>
       </template>
       <v-row v-if="tls.fragment != undefined">
-        <v-col cols="12" sm="6" md="4">
+        <v-col cols="12" sm="6" lg="4">
           <v-switch color="primary" :label="$t('tls.fragment')" v-model="tls.fragment" hide-details></v-switch>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="tls.fragment">
+        <v-col cols="12" sm="6" lg="4" v-if="tls.fragment">
           <v-switch color="primary" :label="$t('tls.recordFragment')" v-model="tls.record_fragment" hide-details></v-switch>
         </v-col>
-        <v-col cols="12" sm="6" md="4" v-if="tls.fragment">
+        <v-col cols="12" sm="6" lg="4" v-if="tls.fragment">
           <v-text-field
           :label="$t('tls.fragmentDelay')"
           hide-details

--- a/src/components/transports/Http.vue
+++ b/src/components/transports/Http.vue
@@ -1,20 +1,20 @@
 <template>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.hosts')"
       hide-details
       v-model="hosts">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.path')"
       hide-details
       v-model="transport.path">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-select
       :label="$t('transport.httpMethod')"
       hide-details
@@ -26,7 +26,7 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.idleTimeout')"
       hide-details
@@ -36,7 +36,7 @@
       v-model.number="idle_timeout">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.pingTimeout')"
       hide-details

--- a/src/components/transports/HttpUpgrade.vue
+++ b/src/components/transports/HttpUpgrade.vue
@@ -1,13 +1,13 @@
 <template>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.hosts')"
       hide-details
       v-model="transport.host">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.path')"
       hide-details

--- a/src/components/transports/WebSocket.vue
+++ b/src/components/transports/WebSocket.vue
@@ -1,13 +1,13 @@
 <template>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.path')"
       hide-details
       v-model="transport.path">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.host')"
       hide-details
@@ -16,7 +16,7 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       label="Max Early Data"
       hide-details
@@ -25,7 +25,7 @@
       v-model.number="max_early_data">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       label="Early Data Header Name"
       hide-details

--- a/src/components/transports/gRPC.vue
+++ b/src/components/transports/gRPC.vue
@@ -1,13 +1,13 @@
 <template>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.grpcServiceName')"
       hide-details
       v-model="transport.service_name">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-switch
         color="primary"
         v-model="transport.permit_without_stream"
@@ -17,7 +17,7 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.idleTimeout')"
       hide-details
@@ -27,7 +27,7 @@
       v-model.number="idle_timeout">
       </v-text-field>
     </v-col>
-    <v-col cols="12" sm="6" md="4">
+    <v-col cols="12" sm="6" lg="4">
       <v-text-field
       :label="$t('transport.pingTimeout')"
       hide-details

--- a/src/layouts/default/AppBar.vue
+++ b/src/layouts/default/AppBar.vue
@@ -1,8 +1,8 @@
 <template>
-  <v-app-bar :elevation="5">
+  <v-app-bar :elevation="2">
     <v-icon v-if="isMobile" icon="mdi-menu" @click="$emit('toggleDrawer')" />
     <span v-else style="width: 24px"></span>
-    <v-app-bar-title :text="$t(<string>route.name)" class="align-center text-center " />
+    <v-app-bar-title :text="$t(<string>route.name)" class="align-center text-center text-truncate" />
     <v-menu>
       <template v-slot:activator="{ props }">
         <v-btn icon v-bind="props">

--- a/src/layouts/default/Default.vue
+++ b/src/layouts/default/Default.vue
@@ -25,14 +25,3 @@ const isMobile = computed( ():boolean =>{
   return smAndDown.value
 })
 </script>
-
-<style>
-.v-card-subtitle {
-  text-align: center;
-  border-bottom: 1px solid gray;
-  min-height: 20px;
-}
-.v-switch.v-input {
-  padding-inline-start: .6rem;
-}
-</style>

--- a/src/layouts/modals/Client.vue
+++ b/src/layouts/modals/Client.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg" :loading="loading">
       <v-card-title>
         {{ $t('actions.' + title) + " " + $t('objects.client') }}
@@ -11,8 +11,8 @@
           type="card, text, divider, list-item-two-line"
           v-if="loading"
         ></v-skeleton-loader>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
-        <v-container style="padding: 0;" :hidden="loading">
+      <v-card-text class="px-4" style="overflow-y: auto;">
+        <div :hidden="loading">
           <v-tabs
             v-model="tab"
             align-tabs="center"
@@ -24,49 +24,49 @@
           <v-window v-model="tab">
             <v-window-item value="t1">
               <v-row>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-switch color="primary" v-model="client.enable" :label="$t('enable')" hide-details></v-switch>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-combobox v-model="client.group" :items="groups" :label="$t('client.group')" hide-details></v-combobox>
                 </v-col>
               </v-row>
               <v-row>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field v-model="client.name" :label="$t('client.name')" hide-details></v-text-field>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field v-model="client.desc" :label="$t('client.desc')" hide-details></v-text-field>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field v-model="client.remark" :label="$t('client.remark')" hide-details></v-text-field>
                 </v-col>
               </v-row>
               <v-row>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field v-model.number="Volume" type="number" min="0" :label="$t('stats.volume')" suffix="GiB" hide-details></v-text-field>
                 </v-col>
-                <v-col cols="12" sm="6" md="4" v-if="!(client.delayStart && !client.autoReset)">
+                <v-col cols="12" sm="6" lg="4" v-if="!(client.delayStart && !client.autoReset)">
                   <DatePick :expiry="expDate" @submit="setDate" />
                 </v-col>
-                <v-col cols="12" sm="6" md="4" v-if="client.autoReset || client.delayStart">
+                <v-col cols="12" sm="6" lg="4" v-if="client.autoReset || client.delayStart">
                   <v-text-field v-model.number="resetDays" type="number" min="1" :label="$t('client.resetDays')" hide-details></v-text-field>
                 </v-col>
               </v-row>
               <v-row>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-switch color="primary"
                     :disabled="client.up+client.down>0"
                     v-model="delayStart"
                     :label="$t('client.delayStart')" hide-details>
                   </v-switch>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-switch color="primary" v-model="autoReset" :label="$t('client.autoReset')" hide-details></v-switch>
                 </v-col>
               </v-row>
               <v-row v-if="id > 0">
-                <v-col cols="12" sm="6" md="4" class="d-flex flex-column">
+                <v-col cols="12" sm="6" lg="4" class="d-flex flex-column">
                   <div class="d-flex justify-space-between align-center">
                     <div>
                       {{ $t('stats.usage') }}: {{ total }}<sup dir="ltr" v-if="percent>0">({{ percent }}%)</sup>
@@ -86,18 +86,18 @@
                   >
                   </v-progress-linear>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-icon icon="mdi-upload" color="warning" /><span class="text-warning">{{ up }}</span>
                   / 
                   <v-icon icon="mdi-download" color="success" /><span class="text-success">{{ down }}</span>
                 </v-col>
               </v-row>
               <v-row v-if="id >0 && client.autoReset">
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <div class="text-medium-emphasis">{{ $t('client.nextReset') }}</div>
                   <div dir="ltr">{{ nextResetFormatted }}</div>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <div class="text-medium-emphasis">{{ $t('main.stats.totalUsage') }}</div>
                   <div>
                     <v-icon icon="mdi-upload" color="warning" /><span class="text-warning">{{ totalUp }}</span>
@@ -125,7 +125,7 @@
             </v-window-item>
             <v-window-item value="t2">
               <v-row>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-btn variant="tonal" @click="shuffle()">{{ $t('reset') + ' - ' + $t('all') }}<v-icon icon="mdi-refresh" /></v-btn>
                 </v-col>
               </v-row>
@@ -201,7 +201,7 @@
               </v-row>
             </v-window-item>
           </v-window>
-        </v-container>
+        </div>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/src/layouts/modals/ClientAddBulk.vue
+++ b/src/layouts/modals/ClientAddBulk.vue
@@ -1,14 +1,14 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title>
         {{ $t('actions.addbulk') }}
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
-        <v-container style="padding: 0;">
+      <v-card-text class="px-4" style="overflow-y: auto;">
+        <div>
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model.number="count" type="number" min="1" max="100" :label="$t('count')" hide-details></v-text-field>
             </v-col>
           </v-row>
@@ -37,27 +37,27 @@
             </v-col>
           </v-row>
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-combobox v-model="bulkData.group" :items="groups" :label="$t('client.group')" hide-details></v-combobox>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model.number="bulkData.Volume" type="number" min="0" :label="$t('stats.volume')" suffix="GiB" hide-details></v-text-field>
             </v-col>
-            <v-col cols="12" sm="6" md="4" v-if="!(bulkData.delayStart && !bulkData.autoReset)">
+            <v-col cols="12" sm="6" lg="4" v-if="!(bulkData.delayStart && !bulkData.autoReset)">
               <DatePick :expiry="bulkData.expiry" @submit="setDate" />
             </v-col>
           </v-row>
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-switch color="primary"
                 v-model="bulkData.delayStart"
                 :label="$t('client.delayStart')" hide-details>
               </v-switch>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-switch color="primary" v-model="bulkData.autoReset" :label="$t('client.autoReset')" hide-details></v-switch>
             </v-col>
-            <v-col cols="12" sm="6" md="4" v-if="bulkData.autoReset || bulkData.delayStart">
+            <v-col cols="12" sm="6" lg="4" v-if="bulkData.autoReset || bulkData.delayStart">
               <v-text-field v-model.number="bulkData.resetDays" type="number" min="1" :label="$t('client.resetDays')" hide-details></v-text-field>
             </v-col>
           </v-row>
@@ -77,7 +77,7 @@
               </v-select>
             </v-col>
           </v-row>
-        </v-container>
+        </div>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/src/layouts/modals/ClientEditBulk.vue
+++ b/src/layouts/modals/ClientEditBulk.vue
@@ -1,16 +1,16 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title>
         {{ $t('actions.editbulk') }}
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
-        <v-container style="padding: 0;">
+      <v-card-text class="px-4" style="overflow-y: auto;">
+        <div>
           <v-card :subtitle="$t('actions.action')" class="mb-4">
             <v-card-text>
               <v-row>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-select
                     v-model="actionMode"
                     :items="actionModes"
@@ -21,7 +21,7 @@
                 </v-col>
               </v-row>
               <v-row v-if="actionMode === 'change_limits'">
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field
                     v-model.number="editData.addDays"
                     type="number"
@@ -30,7 +30,7 @@
                     hide-details
                   ></v-text-field>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field
                     v-model.number="editData.addVolume"
                     type="number"
@@ -39,7 +39,7 @@
                     hide-details
                   ></v-text-field>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-switch
                     v-model="editData.enable"
                     :label="$t('enable')"
@@ -65,7 +65,7 @@
 
           <!-- Section two: Clients (like init users in Inbound modal) -->
           <Users :clients="clients" :data="selectedClients" />
-        </v-container>
+        </div>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/src/layouts/modals/Dns.vue
+++ b/src/layouts/modals/Dns.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.dnsserver') }}
@@ -9,7 +9,7 @@
       <v-divider></v-divider>
       <v-card-text>
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               v-model="dnsServer.type"
               :items="dnsTypes"
@@ -18,15 +18,15 @@
               hide-details
             />
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="dnsServer.tag" :label="$t('objects.tag')" hide-details />
           </v-col>
         </v-row>
         <v-row v-if="HasServer.includes(dnsServer.type)">
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="dnsServer.server" :label="$t('in.addr')" hide-details />
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model.number="dnsServer.server_port" type="number" min="0" :label="$t('in.port')" hide-details />
           </v-col>
         </v-row>
@@ -49,7 +49,7 @@
               <v-chip color="primary" density="compact" variant="elevated" @click="addHostsPredefined"><v-icon icon="mdi-plus" /></v-chip>
             </v-card-subtitle>
             <v-row v-for="(pd, index) in hostsPredefined">
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-text-field v-model="pd.name" :label="$t('setting.domain')" @input="update_pds_key(index,$event.target.value)" hide-details></v-text-field>
               </v-col>
               <v-col cols="12" sm="6">
@@ -67,31 +67,31 @@
           </v-card>
         </template>
         <v-row v-if="dnsServer.type == 'local'">
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-switch v-model="dnsServer.prefer_go" color="primary" :label="$t('dns.local.preferGo')" hide-details></v-switch>
           </v-col>
         </v-row>
         <v-row v-if="dnsServer.type == 'dhcp'">
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="dnsServer.interface" :label="$t('types.tun.ifName')" hide-details />
           </v-col>
         </v-row>
         <v-row v-if="dnsServer.type == 'fakeip'">
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="dnsServer.inet4_range" :label="$t('dns.rule.inet4Range')" hide-details />
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="dnsServer.inet6_range" :label="$t('dns.rule.inet6Range')" hide-details />
           </v-col>
         </v-row>
         <v-row v-if="dnsServer.type == 'tailscale' || dnsServer.type == 'resolved'">
-          <v-col cols="12" sm="6" md="4" v-if="dnsServer.type == 'tailscale'">
+          <v-col cols="12" sm="6" lg="4" v-if="dnsServer.type == 'tailscale'">
             <v-select v-model="dnsServer.endpoint" :label="$t('objects.endpoint')" :items="tsTags" hide-details />
           </v-col>
-          <v-col cols="12" sm="6" md="4" v-if="dnsServer.type == 'resolved'">
+          <v-col cols="12" sm="6" lg="4" v-if="dnsServer.type == 'resolved'">
             <v-select v-model="dnsServer.service" :label="$t('objects.service')" :items="rslvdTags" hide-details />
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-switch v-model="dnsServer.accept_default_resolvers" :label="$t('dns.rule.acceptDefault')" hide-details></v-switch>
           </v-col>
         </v-row>

--- a/src/layouts/modals/DnsRule.vue
+++ b/src/layouts/modals/DnsRule.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.dnsrule') }}
@@ -7,9 +7,9 @@
         <DocLink section="dnsRule" />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px;">
+      <v-card-text class="px-4">
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-switch color="primary" v-model="logical" :label="$t('rule.logical')" hide-details></v-switch>
           </v-col>
           <v-spacer></v-spacer>
@@ -21,7 +21,7 @@
           <v-card-subtitle>{{ $t('objects.rule') + ' ' + (Number(index)+1) }}
             <v-icon @click="ruleData.rules.splice(index,1)" icon="mdi-delete" v-if="ruleData.rules.length>1" />
           </v-card-subtitle>
-          <v-card-text style="padding: 0;">
+          <v-card-text class="pa-0">
             <RuleOptions
               :rule="r"
               :clients="clients"
@@ -36,7 +36,7 @@
           :inTags="inTags"
           :ruleSets="ruleSets" />
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               v-model="ruleData.action"
               :items="actions"
@@ -44,7 +44,7 @@
               hide-details
             ></v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4" v-if="logical">
+          <v-col cols="12" sm="6" lg="4" v-if="logical">
             <v-combobox
               v-model="ruleData.mode"
               :items="['and', 'or']"
@@ -52,13 +52,13 @@
               hide-details
             ></v-combobox>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-switch color="primary" v-model="ruleData.invert" :label="$t('rule.invert')" hide-details></v-switch>
           </v-col>
         </v-row>
         <v-card :subtitle="$t('dns.rule.action.route')" v-if="['route', 'route-options'].includes(ruleData.action)">
           <v-row v-if="ruleData.action == 'route'">
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.server"
                 :items="serverTags"
@@ -66,7 +66,7 @@
                 hide-details
               ></v-select>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.strategy"
                 :items="strategies"
@@ -78,20 +78,20 @@
             </v-col>
           </v-row>
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-switch v-model="ruleData.disable_cache" :label="$t('dns.disableCache')" hide-details></v-switch>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model.number="ruleData.rewrite_ttl" type="number" min="0" :label="$t('dns.rule.action.rewriteTtl')" hide-details></v-text-field>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model="ruleData.client_subnet" :label="$t('dns.rule.action.clientSubnet')" hide-details></v-text-field>
             </v-col>
           </v-row>
         </v-card>
         <v-card :subtitle="$t('dns.rule.action.reject')" v-if="ruleData.action == 'reject'">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.method"
                 :items="[{ title: 'Default', value: 'default' },{ title: 'Drop', value: 'drop'}]"
@@ -101,14 +101,14 @@
                 hide-details>
             </v-select>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-switch v-model="ruleData.no_drop" :label="$t('rule.noDrop')" hide-details></v-switch>
             </v-col>
           </v-row>
         </v-card>
         <v-card :subtitle="$t('dns.rule.action.predefined')" v-if="ruleData.action == 'predefined'">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.rcode"
                 :items="predefinedRcode"

--- a/src/layouts/modals/Endpoint.vue
+++ b/src/layouts/modals/Endpoint.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.endpoint') }}
@@ -7,9 +7,9 @@
         <DocLink section="endpoint" :type="endpoint.type" />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
+      <v-card-text class="px-4 overflow-y-auto">
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
             hide-details
             :disabled="endpoint.id > 0"
@@ -19,7 +19,7 @@
             @update:modelValue="changeType">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="endpoint.tag" :label="$t('objects.tag')" hide-details></v-text-field>
           </v-col>
         </v-row>

--- a/src/layouts/modals/Inbound.vue
+++ b/src/layouts/modals/Inbound.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800" @after-enter="updateData(id)">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900" @after-enter="updateData(id)">
     <v-card class="rounded-lg" :loading="loading">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.inbound') }}
@@ -13,10 +13,10 @@
           type="card, text, divider, list-item-two-line"
           v-if="loading"
         ></v-skeleton-loader>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
-        <v-container style="padding: 0;" :hidden="loading">
+      <v-card-text class="px-4" style="overflow-y: auto;">
+        <div :hidden="loading">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
               hide-details
               :label="$t('type')"
@@ -25,7 +25,7 @@
               @update:modelValue="changeType">
               </v-select>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model="inbound.tag" :label="$t('objects.tag')" hide-details></v-text-field>
             </v-col>
           </v-row>
@@ -39,7 +39,7 @@
             <v-tab value="s">{{ $t('in.sSide') }}</v-tab>
             <v-tab value="c">{{ $t('in.cSide') }}</v-tab>
           </v-tabs>
-          <v-window v-model="side" style="margin-top: 10px;">
+          <v-window v-model="side">
             <v-window-item value="s">
               <Listen :data="inbound" :inTags="inTags" v-if="inbound.type != inTypes.Tun" />
               <Direct v-if="inbound.type == inTypes.Direct" :data="inbound" />
@@ -75,7 +75,7 @@
               </v-card>
             </v-window-item>
           </v-window>
-        </v-container>
+        </div>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/src/layouts/modals/Logs.vue
+++ b/src/layouts/modals/Logs.vue
@@ -13,7 +13,7 @@
       <v-divider></v-divider>
       <v-card-text>
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
             hide-details
             :label="$t('basic.log.level')"
@@ -22,7 +22,7 @@
             @update:model-value="loadData">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
             hide-details
             :label="$t('count')"
@@ -41,7 +41,7 @@
             </v-btn>
           </v-col>
         </v-row>
-        <v-card style="margin-top: .5rem;" color="background" dir="ltr" v-html="lines.join('<br />')"></v-card>
+        <v-card class="mt-2 border" rounded="lg" color="background" dir="ltr" v-html="lines.join('<br />')"></v-card>
       </v-card-text>
     </v-card>
   </v-dialog>

--- a/src/layouts/modals/Outbound.vue
+++ b/src/layouts/modals/Outbound.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.outbound') }}
@@ -7,8 +7,8 @@
         <DocLink section="outbound" :type="outbound.type" />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
-        <v-container style="padding: 0;">
+      <v-card-text class="px-4" style="overflow-y: auto;">
+        <div>
           <v-tabs
             v-model="tab"
             align-tabs="center"
@@ -19,7 +19,7 @@
           <v-window v-model="tab">
             <v-window-item value="t1">
               <v-row>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-select
                   hide-details
                   :label="$t('type')"
@@ -28,19 +28,19 @@
                   @update:modelValue="changeType">
                   </v-select>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field v-model="outbound.tag" :label="$t('objects.tag')" hide-details></v-text-field>
                 </v-col>
               </v-row>
               <v-row v-if="!NoServer.includes(outbound.type)">
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field
                   :label="$t('out.addr')"
                   hide-details
                   v-model="outbound.server">
                   </v-text-field>
                 </v-col>
-                <v-col cols="12" sm="6" md="4">
+                <v-col cols="12" sm="6" lg="4">
                   <v-text-field
                   :label="$t('out.port')"
                   type="number"
@@ -83,7 +83,7 @@
               </v-row>
             </v-window-item>
           </v-window>
-        </v-container>
+        </div>
       </v-card-text>
       <v-card-actions>
         <v-spacer></v-spacer>

--- a/src/layouts/modals/OutboundBulk.vue
+++ b/src/layouts/modals/OutboundBulk.vue
@@ -1,11 +1,11 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800" :model-value="visible">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900" :model-value="visible">
     <v-card class="rounded-lg">
       <v-card-title>
         {{ $t('actions.addbulk') }} {{ $t('objects.outbound') }}
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
+      <v-card-text class="px-4 overflow-y-auto">
         <v-row v-if="outbounds.length==0">
           <v-col cols="12">
             <v-text-field v-model="link"

--- a/src/layouts/modals/QrCode.vue
+++ b/src/layouts/modals/QrCode.vue
@@ -15,7 +15,7 @@
           type="text, image, divider, text, image"
           v-if="loading"
         ></v-skeleton-loader>
-      <v-card-text style="overflow-y: auto; padding: 0" :hidden="loading">
+      <v-card-text class="px-4 pt-4" style="overflow-y: auto;" :hidden="loading">
         <v-tabs
           v-model="tab"
           density="compact"
@@ -25,7 +25,7 @@
           <v-tab value="sub">{{ $t('setting.sub') }}</v-tab>
           <v-tab value="link">{{ $t('client.links') }}</v-tab>
         </v-tabs>
-        <v-window v-model="tab" style="margin-top: 10px;">
+        <v-window v-model="tab">
           <v-window-item value="sub">
             <v-row>
               <v-col style="text-align: center;">

--- a/src/layouts/modals/Rule.vue
+++ b/src/layouts/modals/Rule.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.rule') }}
@@ -7,9 +7,9 @@
         <DocLink section="rule" />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px;">
+      <v-card-text class="px-4">
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-switch color="primary" v-model="logical" :label="$t('rule.logical')" hide-details></v-switch>
           </v-col>
           <v-spacer></v-spacer>
@@ -21,7 +21,7 @@
           <v-card-subtitle>{{ $t('objects.rule') + ' ' + (Number(index)+1) }}
             <v-icon @click="ruleData.rules.splice(index,1)" icon="mdi-delete" v-if="ruleData.rules.length>1" />
           </v-card-subtitle>
-          <v-card-text style="padding: 0;">
+          <v-card-text class="pa-0">
             <RuleOptions
               :rule="r"
               :clients="clients"
@@ -38,7 +38,7 @@
           :outTags="outTags"
           :rsTags="rsTags" />
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               v-model="ruleData.action"
               :items="actions"
@@ -46,7 +46,7 @@
               hide-details
             ></v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4" v-if="logical">
+          <v-col cols="12" sm="6" lg="4" v-if="logical">
             <v-combobox
               v-model="ruleData.mode"
               :items="['and', 'or']"
@@ -54,13 +54,13 @@
               hide-details
             ></v-combobox>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-switch color="primary" v-model="ruleData.invert" :label="$t('rule.invert')" hide-details></v-switch>
           </v-col>
         </v-row>
         <v-card subtitle="Route" v-if="ruleData.action == 'route'">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.outbound"
                 :items="outTags"
@@ -72,10 +72,10 @@
         </v-card>
         <v-card subtitle="Route Option" v-if="ruleData.action == 'route-options'">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model="ruleData.override_address" :label="$t('types.direct.overrideAddr')" hide-details></v-text-field>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field
                 v-model.number="ruleData.override_port"
                 type="number"
@@ -85,20 +85,20 @@
                 hide-details>
               </v-text-field>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-switch v-model="ruleData.udp_disable_domain_unmapping" :label="$t('rule.udpDisableDomainUnmapping')" hide-details></v-switch>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-switch v-model="ruleData.udp_connect" :label="$t('rule.udpConnect')" hide-details></v-switch>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model="ruleData.udp_timeout" :label="$t('rule.udpTimeout')" hide-details></v-text-field>
             </v-col>
           </v-row>
         </v-card>
         <v-card subtitle="Reject" v-if="ruleData.action == 'reject'">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.method"
                 :items="[{ title: 'Default', value: 'default' },{ title: 'Drop', value: 'drop'}]"
@@ -108,14 +108,14 @@
                 hide-details>
             </v-select>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-switch v-model="ruleData.no_drop" :label="$t('rule.noDrop')" hide-details></v-switch>
             </v-col>
           </v-row>
         </v-card>
         <v-card subtitle="Sniff" v-if="ruleData.action == 'sniff'">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.sniffer"
                 :items="sniffers"
@@ -125,14 +125,14 @@
                 hide-details>
               </v-select>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model="ruleData.timeout" :label="$t('rule.timeout')" hide-details></v-text-field>
             </v-col>
           </v-row>
         </v-card>
         <v-card subtitle="Resolve" v-if="ruleData.action == 'resolve'">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 v-model="ruleData.strategy"
                 :items="strategies"
@@ -142,7 +142,7 @@
                 hide-details>
               </v-select>
             </v-col>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field v-model="ruleData.server" :label="$t('basic.dns.server')" hide-details></v-text-field>
             </v-col>
           </v-row>

--- a/src/layouts/modals/RuleImport.vue
+++ b/src/layouts/modals/RuleImport.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-top-transition" width="800">
+  <v-dialog transition="dialog-top-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title>
         <v-row>
@@ -14,7 +14,7 @@
         </v-row>
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
+      <v-card-text class="px-4 overflow-y-auto">
         <v-tabs v-model="tab" @update:modelValue="tabChanged">
           <v-tab value="json">JSON</v-tab>
           <v-tab value="file">{{ $t('rule.import.uploadFile') }}</v-tab>
@@ -81,7 +81,7 @@
             <v-checkbox v-model="applyFinal" :label="$t('rule.import.applyFinal')" hide-details density="compact" />
           </v-alert>
 
-          <span class="v-card-subtitle">
+          <span class="text-subtitle-2 text-medium-emphasis">
             {{ $t('pages.rules') }}
             <v-badge v-if="parsed.rules?.length > 0" color="success" :content="parsed.rules?.length" inline />
           </span>
@@ -99,7 +99,7 @@
             </tbody>
           </v-table>
 
-          <span class="v-card-subtitle">
+          <span class="text-subtitle-2 text-medium-emphasis">
             {{ $t('rule.ruleset') }}
             <v-badge v-if="parsed.rule_set?.length > 0" color="success" :content="parsed.rule_set?.length" inline />
             <span v-if="skippedRulesets > 0">

--- a/src/layouts/modals/Ruleset.vue
+++ b/src/layouts/modals/Ruleset.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.ruleset') }}
@@ -7,9 +7,9 @@
         <DocLink section="ruleset" />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px;">
+      <v-card-text class="px-4">
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               hide-details
               :label="$t('type')"
@@ -18,10 +18,10 @@
               v-model="rule_set.type">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="rule_set.tag" :label="$t('objects.tag')" hide-details></v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               hide-details
               :label="$t('ruleset.format')"
@@ -39,7 +39,7 @@
           <v-col cols="12">
             <v-text-field v-model="rule_set.url" label="URL" hide-details></v-text-field>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               hide-details
               :label="$t('objects.outbound')"
@@ -49,7 +49,7 @@
               v-model="rule_set.download_detour">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model.number="update_intervals" :suffix="$t('date.d')" type="number" min="0" :label="$t('ruleset.interval')" hide-details></v-text-field>
           </v-col>
         </v-row>

--- a/src/layouts/modals/RulesetImport.vue
+++ b/src/layouts/modals/RulesetImport.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-top-transition" width="800">
+  <v-dialog transition="dialog-top-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title>
         <v-row>
@@ -12,7 +12,7 @@
         </v-row>
       </v-card-title>
       <v-divider />
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
+      <v-card-text class="px-4 overflow-y-auto">
         <v-tabs v-model="tab" @update:modelValue="tabChanged">
           <v-tab value="text">
             {{ $t('rule.import.pasteUrls') }}
@@ -48,7 +48,7 @@
           </v-window-item>
         </v-window>
         <v-row class="mb-4">
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               hide-details
               :label="$t('ruleset.format')"
@@ -56,7 +56,7 @@
               v-model="importFormat">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
               hide-details
               :label="$t('objects.outbound')"
@@ -66,14 +66,14 @@
               v-model="importDetour">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model.number="importInterval" :suffix="$t('date.d')" type="number" min="0" :label="$t('ruleset.interval')" hide-details></v-text-field>
           </v-col>
         </v-row>
 
         <template v-if="importPreview.length > 0">
           <v-divider class="my-4" />
-          <span class="v-card-subtitle">
+          <span class="text-subtitle-2 text-medium-emphasis">
             {{ $t('rule.import.preview') }}
             <v-badge v-if="importPreview.length > 0" color="success" :content="importPreview.length" inline />
             <v-badge v-if="importSkipped > 0" color="warning" :content="importSkipped" inline v-tooltip:top="$t('rule.import.skipped')" />

--- a/src/layouts/modals/Service.vue
+++ b/src/layouts/modals/Service.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.service') }}
@@ -7,9 +7,9 @@
         <DocLink section="service" :type="srv.type" />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
+      <v-card-text class="px-4 overflow-y-auto">
         <v-row>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-select
             hide-details
             :label="$t('type')"
@@ -18,7 +18,7 @@
             @update:modelValue="changeType">
             </v-select>
           </v-col>
-          <v-col cols="12" sm="6" md="4">
+          <v-col cols="12" sm="6" lg="4">
             <v-text-field v-model="srv.tag" :label="$t('objects.tag')" hide-details></v-text-field>
           </v-col>
         </v-row>

--- a/src/layouts/modals/Stats.vue
+++ b/src/layouts/modals/Stats.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg" :loading="loading">
       <v-card-title>
         <v-row>
@@ -10,10 +10,10 @@
           <v-col cols="auto"><v-icon icon="mdi-close" @click="$emit('close')"></v-icon></v-col>
         </v-row>
       </v-card-title>
-      <v-card-subtitle style="margin-top: -20px">
+      <v-card-subtitle>
         {{ $t('objects.' + resource) + " : " + tag }}
       </v-card-subtitle>
-      <v-card-text class="text-center" style="padding: 0">
+      <v-card-text class="text-center pa-0">
         <v-btn-toggle v-model="limit"
           @update:model-value="selectPreset" density="compact"
           color="primary" :loading="loading"

--- a/src/layouts/modals/Tls.vue
+++ b/src/layouts/modals/Tls.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg">
       <v-card-title class="d-flex align-center">
         {{ $t('actions.' + title) + " " + $t('objects.tls') }}
@@ -7,10 +7,10 @@
         <DocLink section="tls" />
       </v-card-title>
       <v-divider></v-divider>
-      <v-card-text style="padding: 0 16px; overflow-y: scroll;">
+      <v-card-text class="px-4 overflow-y-auto">
         <v-card class="rounded-lg">
           <v-row>
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-text-field
                 :label="$t('client.name')"
                 hide-details
@@ -31,7 +31,7 @@
             </v-col>
           </v-row>
           <v-row>
-            <v-col cols="12" sm="6" md="4" v-if="inTls.server_name != undefined">
+            <v-col cols="12" sm="6" lg="4" v-if="inTls.server_name != undefined">
               <v-text-field
                 label="SNI"
                 hide-details
@@ -39,7 +39,7 @@
               </v-text-field>
             </v-col>
             <template v-if="tlsType == 0">
-              <v-col cols="12" sm="6" md="4" v-if="inTls.min_version">
+              <v-col cols="12" sm="6" lg="4" v-if="inTls.min_version">
                 <v-select
                   hide-details
                   :label="$t('tls.minVer')"
@@ -47,7 +47,7 @@
                   v-model="inTls.min_version">
                 </v-select>
               </v-col>
-              <v-col cols="12" sm="6" md="4" v-if="inTls.max_version">
+              <v-col cols="12" sm="6" lg="4" v-if="inTls.max_version">
                 <v-select
                   hide-details
                   :label="$t('tls.maxVer')"
@@ -55,7 +55,7 @@
                   v-model="inTls.max_version">
                 </v-select>
               </v-col>
-              <v-col cols="12" sm="6" md="4" v-if="inTls.alpn">
+              <v-col cols="12" sm="6" lg="4" v-if="inTls.alpn">
                 <v-select
                   hide-details
                   label="ALPN"
@@ -140,24 +140,24 @@
               </v-col>
             </v-row>
             <v-row>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-switch color="primary" :label="$t('tls.disableSni')" v-model="disableSni" hide-details></v-switch>
               </v-col>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-switch color="primary" :label="$t('tls.insecure')" v-model="insecure" hide-details></v-switch>
               </v-col>
             </v-row>
           </template>
           <template v-if="outTls.reality && inTls.reality">
             <v-row>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-text-field
                 :label="$t('types.shdwTls.hs')"
                 hide-details
                 v-model="inTls.reality.handshake.server">
                 </v-text-field>
               </v-col>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-text-field
                 :label="$t('out.port')"
                 type="number"
@@ -205,7 +205,7 @@
                   v-model="short_id">
                 </v-text-field>
               </v-col>
-              <v-col cols="12" sm="6" md="4" v-if="optionTime">
+              <v-col cols="12" sm="6" lg="4" v-if="optionTime">
                 <v-text-field
                 label="Max Time Diference"
                 type="number"
@@ -218,7 +218,7 @@
             </v-row>
           </template>
           <v-row v-if="optionStore || optionKtls">
-            <v-col cols="12" sm="6" md="4" v-if="optionStore">
+            <v-col cols="12" sm="6" lg="4" v-if="optionStore">
               <v-select
                 hide-details
                 :label="$t('tls.store')"
@@ -227,16 +227,16 @@
               </v-select>
             </v-col>
             <template v-if="optionKtls">
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-switch color="primary" :label="$t('tls.kernelTx')" v-model="inTls.kernel_tx" hide-details></v-switch>
               </v-col>
-              <v-col cols="12" sm="6" md="4">
+              <v-col cols="12" sm="6" lg="4">
                 <v-switch color="primary" :label="$t('tls.kernelRx')" v-model="inTls.kernel_rx" hide-details></v-switch>
               </v-col>
             </template>
           </v-row>
           <v-row v-if="outTls.utls != undefined">
-            <v-col cols="12" sm="6" md="4">
+            <v-col cols="12" sm="6" lg="4">
               <v-select
                 hide-details
                 label="Fingerprint"

--- a/src/layouts/modals/Token.vue
+++ b/src/layouts/modals/Token.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-dialog transition="dialog-bottom-transition" width="800">
+  <v-dialog transition="dialog-bottom-transition" width="100%" max-width="900">
     <v-card class="rounded-lg" :loading="loading">
       <v-card-title>
         <v-row>

--- a/src/plugins/vuetify.ts
+++ b/src/plugins/vuetify.ts
@@ -18,17 +18,34 @@ import { createVuetify } from 'vuetify'
 export default createVuetify({
   defaults: {
     VRow: { density: 'compact' },
+    VCard: {
+      elevation: 0,
+      rounded: 'lg',
+    },
     VTextField: {
-      variant: 'solo-filled',
+      variant: 'outlined',
+      density: 'comfortable',
     },
     VSelect: {
-      variant: 'solo-filled',
+      variant: 'outlined',
+      density: 'comfortable',
     },
     VCombobox: {
-      variant: 'solo-filled',
+      variant: 'outlined',
+      density: 'comfortable',
     },
     VTextarea: {
-      variant: 'solo-filled',
+      variant: 'outlined',
+      density: 'comfortable',
+    },
+    VSwitch: {
+      density: 'compact',
+      color: 'primary',
+      inset: true,
+      size: 'small',
+    },
+    VListItem: {
+      density: 'compact',
     },
   },
   theme: {

--- a/src/styles/settings.scss
+++ b/src/styles/settings.scss
@@ -4,36 +4,158 @@
  * Configures SASS variables and Vuetify overwrites
  */
 
-// https://vuetifyjs.com/features/sass-variables/`
+// https://vuetifyjs.com/en/features/sass-variables/`
 // @use 'vuetify/settings' with (
 //   $color-pack: false
 // );
-@font-face {
-    font-display: swap;
-    font-family: 'Vazirmatn';
-    font-style: normal;
-    font-weight: 400;
-    src: url('@/assets/Vazirmatn-UI-NL-Regular.woff2') format('woff2');
-    unicode-range: U+0600-06FF, U+200C-200E, U+2010-2011, U+204F, U+2E41, U+FB50-FDFF, U+FE80-FEFC, U+0030-0039;
-}
-$body-font-family: "Vazirmatn";
 
-$typoOptions: text-h1, text-sm-h1, text-md-h1, text-lg-h1, text-h2, text-sm-h2,
-  text-md-h2, text-lg-h2, text-h3, text-sm-h3, text-md-h3, text-lg-h3, text-h4,
-  text-sm-h4, text-md-h4, text-lg-h4, text-h5, text-sm-h5, text-md-h5,
-  text-lg-h5, text-h6, text-sm-h6, text-md-h6, text-lg-h6, headline, title,
-  subtitle-1, subtitle-2, text-body-1, text-sm-body-1, text-md-body-1,
-  text-lg-body-1, text-body-2, text-sm-body-2, text-md-body-2, text-lg-body-2,
-  text-caption;
+@font-face {
+  font-display: swap;
+  font-family: 'Vazirmatn';
+  font-style: normal;
+  font-weight: 400;
+  src: url('@/assets/Vazirmatn-UI-NL-Regular.woff2') format('woff2');
+  unicode-range: U+0600-06FF, U+200C-200E, U+2010-2011, U+204F, U+2E41, U+FB50-FDFF, U+FE80-FEFC, U+0030-0039;
+}
+
+// Default UI font: native system stack (no Roboto dependency, no Persian font for non-fa)
 body {
-  font-family: -apple-system, BlinkMacSystemFont, $body-font-family, sans-serif !important;
-  @each $typoOption in $typoOptions {
-    .#{$typoOption} {
-      font-family: -apple-system, BlinkMacSystemFont, $body-font-family, sans-serif !important;
-    }
-  }
+  font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', Roboto, 'Helvetica Neue', sans-serif;
+}
+
+// Persian font only when the document language is fa
+:lang(fa) {
+  font-family: -apple-system, BlinkMacSystemFont, 'Vazirmatn', sans-serif;
 }
 
 .v-btn {
   letter-spacing: 0;
 }
+
+// --- Root-cause: eliminate the "card-in-card" stacking feeling ----------------
+// Top-level cards: thin uniform border, no heavy shadow (elevation handled via defaults=0)
+.v-card {
+  border: 1px solid rgba(var(--v-theme-on-surface), 0.12);
+}
+
+// Nested cards (section wrappers inside dialogs): fully flat — no border, no surface
+// background, no shadow, no radius. They become transparent fieldsets, killing the
+// "one layer wrapping another" bloat. Cards that explicitly opt into a border
+// (class="border", e.g. peer/user item cards) are excluded so list items stay framed.
+.v-card .v-card:not(.border) {
+  background: transparent;
+  border: 0;
+  border-radius: 0;
+  box-shadow: none;
+}
+
+// Flush nested section padding so content aligns with the dialog body
+.v-card .v-card:not(.border) > .v-card-title,
+.v-card .v-card:not(.border) > .v-card-subtitle,
+.v-card .v-card:not(.border) > .v-card-text {
+  padding-inline: 0;
+}
+.v-card .v-card:not(.border) > .v-card-text {
+  padding-block: 0;
+}
+
+// --- Root-cause: dialog form spacing & anti-wrap --------------------------------
+// Dialog titles and tab labels must never wrap (long translations break layout alignment)
+.v-dialog .v-card-title {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.v-tabs .v-tab {
+  white-space: nowrap;
+}
+
+// App bar title: truncate instead of wrapping into the toolbar
+.v-app-bar-title .v-app-bar-title__text {
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+// Form rows inside dialogs: consistent vertical breathing room between fields.
+.v-dialog .v-card-text .v-row + .v-row {
+  margin-top: 4px;
+}
+
+// ROOT CAUSE: an outlined field's floating label uses `transform: translateY(-50%)`
+// and climbs ~9px (comfortable density) above the field's top border. When the
+// field is the first row inside a v-window that immediately follows another
+// element (tabs, a button row, anything), the label has no room to float and is
+// clipped/overlapped by that preceding element.
+//
+// This is NOT a dialog-only issue: Settings.vue is a plain v-card (not a dialog)
+// with `button row + v-window + first outlined row`, and shows the same defect.
+// So the fix must be scope-agnostic: give any v-window that has a preceding
+// sibling a safe top gap. `:not(:first-child)` avoids adding margin to windows
+// that are already the first element (no overlap risk there).
+.v-window:not(:first-child) {
+  margin-top: 16px;
+}
+
+// ROOT CAUSE (dialog-only): Vuetify ships a dialog-specific rule
+//   .v-dialog > .v-overlay__content > .v-card > .v-card-text { padding: 16px 24px 24px }
+// with specificity (0,0,4,0) that BEATS a plain `.v-card-text` override, so the
+// dialog body top padding collapsed to 16px — too tight for an outlined label
+// floating above the first row when the window's own 16px (above) plus the
+// field's float still close on the divider/title. Use the SAME high-specificity
+// child selector as Vuetify (loaded later via settings.scss) to restore a safe
+// top gap inside dialog bodies specifically.
+// Also re-declare the horizontal padding explicitly so the safe edge spacing is
+// guaranteed regardless of which Vuetify dialog padding branch matches (some
+// dialogs land on the generic `.v-card-text { padding: 1rem }` branch which is
+// only 16px — visually fine, but making it explicit avoids any edge case where
+// content sits flush against the left/right card border).
+.v-dialog > .v-overlay__content > .v-card > .v-card-text,
+.v-dialog > .v-overlay__content > form > .v-card > .v-card-text {
+  padding: 24px 24px 24px;
+}
+
+// Outlined floating label: opaque surface background so the label "notch" reads
+// cleanly over any divider/border line behind it (theme-aware, matches card surface).
+.v-field--variant-outlined .v-label.v-field-label--floating {
+  background: rgb(var(--v-theme-surface));
+  padding-inline: 4px;
+}
+
+// Inputs: a touch of bottom breathing space so labels/hints don't collide with the
+// next field. Keep small to preserve density.
+.v-text-field.v-input--density-comfortable,
+.v-select.v-input--density-comfortable,
+.v-combobox.v-input--density-comfortable,
+.v-textarea.v-input--density-comfortable {
+  margin-bottom: 4px;
+}
+
+// --- Root-cause: thin, theme-aware scrollbars ----------------------------------
+// Replace the heavy OS default scrollbar with a slim one that matches the theme.
+// Firefox: thin + theme-aware via scrollbar-color. Chrome/Safari/Edge: webkit.
+* {
+  scrollbar-width: thin;
+  scrollbar-color: rgba(var(--v-theme-on-surface), 0.25) transparent;
+}
+::-webkit-scrollbar {
+  width: 8px;
+  height: 8px;
+}
+::-webkit-scrollbar-track {
+  background: transparent;
+}
+::-webkit-scrollbar-thumb {
+  background: rgba(var(--v-theme-on-surface), 0.25);
+  border-radius: 4px;
+}
+::-webkit-scrollbar-thumb:hover {
+  background: rgba(var(--v-theme-on-surface), 0.4);
+}
+// Dialogs: even thinner webkit scrollbar (6px vs global 8px).
+// Firefox already uses `thin` from the global rule above.
+.v-dialog ::-webkit-scrollbar {
+  width: 6px;
+  height: 6px;
+}
+

--- a/src/views/Admins.vue
+++ b/src/views/Admins.vue
@@ -20,14 +20,14 @@
   />
   <v-row>
     <v-col cols="12" justify="center" align="center">
-      <v-btn color="primary" @click="showChangesModal('')" style="margin: 0 5px;">{{ $t('admin.changes') }}</v-btn>
+      <v-btn color="primary" @click="showChangesModal('')" class="mx-1">{{ $t('admin.changes') }}</v-btn>
       <v-btn color="primary" @click="showTokenModal()">{{ $t('admin.api.token') }}</v-btn>
     </v-col>
   </v-row>
   <v-row>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>users" :key="item.id">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.username">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.username">
+        <v-card-subtitle>
           {{ $t('admin.lastLogin') }}
         </v-card-subtitle>
         <v-card-text>
@@ -51,7 +51,7 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-account-edit" @click="showEditModal(item)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>

--- a/src/views/Basics.vue
+++ b/src/views/Basics.vue
@@ -1,5 +1,5 @@
 <template>
-  <v-row style="margin-bottom: 10px;">
+  <v-row class="mb-2">
     <v-col cols="12" justify="center" align="center">
       <v-btn variant="outlined" color="warning" @click="saveConfig" :loading="loading" :disabled="stateChange">
         {{ $t('actions.save') }}
@@ -91,7 +91,7 @@
       </v-expansion-panel-title>
       <v-expansion-panel-text>
         <v-row>
-          <v-col class="v-card-subtitle">Cache File <DocLink :href="CACHE_FILE_DOC" /></v-col>
+          <v-col class="text-subtitle-2 text-medium-emphasis mt-2">Cache File <DocLink :href="CACHE_FILE_DOC" /></v-col>
         </v-row>
         <v-row>
           <v-col cols="12" sm="6" md="3" lg="2">
@@ -119,7 +119,7 @@
           </v-col>
         </v-row>
         <v-row>
-          <v-col class="v-card-subtitle">Clash API <DocLink :href="CLASH_API_DOC" /></v-col>
+          <v-col class="text-subtitle-2 text-medium-emphasis mt-2">Clash API <DocLink :href="CLASH_API_DOC" /></v-col>
         </v-row>
         <v-row>
           <v-col cols="12" sm="6" md="3" lg="2">
@@ -188,7 +188,7 @@
           </v-col>
         </v-row>
         <v-row>
-          <v-col class="v-card-subtitle">V2Ray API <DocLink :href="V2RAY_API_DOC" /></v-col>
+          <v-col class="text-subtitle-2 text-medium-emphasis mt-2">V2Ray API <DocLink :href="V2RAY_API_DOC" /></v-col>
         </v-row>
         <v-row>
           <v-col cols="12" sm="6" md="3" lg="2">

--- a/src/views/Clients.vue
+++ b/src/views/Clients.vue
@@ -157,7 +157,7 @@
         :mobile="smAndDown"
         mobile-breakpoint="sm"
         width="100%"
-        class="elevation-3 rounded"
+        class="rounded"
         >
         <template v-slot:item.inbounds="{ item }">
           <span>
@@ -332,7 +332,7 @@ const headers = [
   { title: i18n.global.t('client.name'), key: 'name' },
   { title: i18n.global.t('client.desc'), key: 'desc' },
   { title: i18n.global.t('client.group'), key: 'group' },
-  { title: i18n.global.t('pages.inbounds'), key: 'inbounds', width: 10 },
+  { title: i18n.global.t('pages.inbounds'), key: 'inbounds', nowrap: true },
   { title: i18n.global.t('actions.action'), key: 'actions', sortable: false },
   { title: i18n.global.t('stats.volume'), key: 'volume' },
   { title: i18n.global.t('date.expiry'), key: 'expiry' },

--- a/src/views/Dns.vue
+++ b/src/views/Dns.vue
@@ -23,15 +23,15 @@
   />
   <v-row>
     <v-col cols="12" justify="center" align="center">
-      <v-btn color="primary" @click="showDnsModal(-1)" style="margin: 0 5px;">{{ $t('dns.add') }}</v-btn>
-      <v-btn color="primary" @click="showDnsRuleModal(-1)" style="margin: 0 5px;">{{ $t('dns.rule.add') }}</v-btn>
+      <v-btn color="primary" @click="showDnsModal(-1)" class="mx-1">{{ $t('dns.add') }}</v-btn>
+      <v-btn color="primary" @click="showDnsRuleModal(-1)" class="mx-1">{{ $t('dns.rule.add') }}</v-btn>
       <v-btn variant="outlined" color="warning" @click="saveConfig" :loading="loading" :disabled="stateChange">
         {{ $t('actions.save') }}
       </v-btn>
     </v-col>
   </v-row>
   <v-row>
-    <v-col class="v-card-subtitle" cols="12">{{ $t('pages.basics') }}</v-col>
+    <v-col class="text-subtitle-2 text-medium-emphasis mt-2" cols="12">{{ $t('pages.basics') }}</v-col>
     <v-col cols="12">
       <v-row>
         <v-col cols="12" sm="6" md="3" lg="2">
@@ -81,10 +81,10 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col class="v-card-subtitle" cols="12">{{ $t('dns.title') }}</v-col>
+    <v-col class="text-subtitle-2 text-medium-emphasis mt-2" cols="12">{{ $t('dns.title') }}</v-col>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>dns.servers" :key="item.id">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.tag">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.tag">
+        <v-card-subtitle>
           <v-row>
             <v-col>{{ item.type }}</v-col>
           </v-row>
@@ -110,12 +110,12 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showDnsModal(index)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delDnsOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delDnsOverlay[index] = true">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>
@@ -138,7 +138,7 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col class="v-card-subtitle" cols="12">{{ $t('dns.rule.title') }}</v-col>
+    <v-col class="text-subtitle-2 text-medium-emphasis mt-2" cols="12">{{ $t('dns.rule.title') }}</v-col>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>dnsRules"
       :key="item.id"
       :draggable="true"
@@ -146,8 +146,8 @@
       @dragover.prevent
       @drop="onDrop(index)"
       >
-      <v-card rounded="xl" elevation="5" min-width="200" :title="index+1">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="index+1">
+        <v-card-subtitle>
           <v-row>
             <v-col>{{ item.type != undefined ? $t('rule.logical') + ' (' + item.mode + ')' : $t('rule.simple') }}</v-col>
           </v-row>
@@ -179,12 +179,12 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showDnsRuleModal(index)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delDnsRuleOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delDnsRuleOverlay[index] = true">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>

--- a/src/views/Endpoints.vue
+++ b/src/views/Endpoints.vue
@@ -27,8 +27,8 @@
   </v-row>
   <v-row>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>endpoints" :key="item.tag">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.tag">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.tag">
+        <v-card-subtitle>
           <v-row>
             <v-col>{{ item.type }}</v-col>
           </v-row>
@@ -63,12 +63,12 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showModal(item.id)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delOverlay[index] = true">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>

--- a/src/views/Inbounds.vue
+++ b/src/views/Inbounds.vue
@@ -21,8 +21,8 @@
   </v-row>
   <v-row>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>inbounds" :key="item.tag">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.tag">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.tag">
+        <v-card-subtitle>
           <v-row>
             <v-col>{{ item.type }}</v-col>
           </v-row>
@@ -69,12 +69,12 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showModal(item.id)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delOverlay[index] = true">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>

--- a/src/views/Login.vue
+++ b/src/views/Login.vue
@@ -1,53 +1,63 @@
 <template>
-    <v-container class="fill-height" style="margin-top: 100px;">
-      <v-row justify="center" align="center">
-        <v-col cols="12" sm="8" md="4">
-          <v-card>
-            <v-card-title class="headline" v-text="$t('login.title')"></v-card-title>
-            <v-card-text>
-              <v-form @submit.prevent="login" ref="form">
-                <v-text-field v-model="username" :label="$t('login.username')" :rules="usernameRules" required></v-text-field>
-                <v-text-field v-model="password" :label="$t('login.password')" :rules="passwordRules" type="password" required></v-text-field>
-                <v-btn :loading="loading" type="submit" color="primary" block class="mt-2" v-text="$t('actions.submit')"></v-btn>
-              </v-form>
-              <v-select
-                density="compact"
-                class="mt-2"
-                hide-details
-                variant="solo"
-                :items="languages"
-                v-model="$i18n.locale"
-                @update:modelValue="changeLocale">
-                <template v-slot:append>
-                  <v-menu>
-                    <template v-slot:activator="{ props }">
-                      <v-btn icon v-bind="props">
-                        <v-icon>mdi-theme-light-dark</v-icon>
-                      </v-btn>
-                    </template>
-                    <v-list>
-                      <v-list-item
-                        v-for="th in themes"
-                        :key="th.value"
-                        @click="changeTheme(th.value)"
-                        :prepend-icon="th.icon"
-                        :active="isActiveTheme(th.value)"
-                      >
-                        <v-list-item-title>{{ $t(`theme.${th.value}`) }}</v-list-item-title>
-                      </v-list-item>
-                    </v-list>
-                  </v-menu>
+    <div class="login-wrap">
+      <v-card class="login-card pa-2">
+        <v-card-title class="text-h5 text-center text-no-wrap" v-text="$t('login.title')"></v-card-title>
+        <v-card-text>
+          <v-form @submit.prevent="login" ref="form">
+            <v-text-field v-model="username" :label="$t('login.username')" :rules="usernameRules" required class="mb-2"></v-text-field>
+            <v-text-field v-model="password" :label="$t('login.password')" :rules="passwordRules" type="password" required class="mb-2"></v-text-field>
+            <v-btn :loading="loading" type="submit" color="primary" block size="large" class="mt-2" v-text="$t('actions.submit')"></v-btn>
+          </v-form>
+          <v-row class="mt-4" align="center" justify="center" no-gutters>
+            <v-col cols="auto">
+              <v-menu>
+                <template v-slot:activator="{ props }">
+                  <v-btn v-bind="props" variant="text" size="small">
+                    <v-icon icon="mdi-translate" start></v-icon>
+                    <span class="text-no-wrap">{{ currentLanguageTitle }}</span>
+                  </v-btn>
                 </template>
-              </v-select>
-            </v-card-text>
-          </v-card>
-        </v-col>
-      </v-row>
-    </v-container>
+                <v-list density="compact" nav>
+                  <v-list-item
+                    v-for="lang in languages"
+                    :key="lang.value"
+                    @click="changeLocale(lang.value)"
+                    :active="isActiveLocale(lang.value)"
+                  >
+                    <v-list-item-title>{{ lang.title }}</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-menu>
+            </v-col>
+            <v-col cols="auto">
+              <v-menu>
+                <template v-slot:activator="{ props }">
+                  <v-btn v-bind="props" variant="text" size="small">
+                    <v-icon :icon="currentThemeIcon" start></v-icon>
+                    <span class="text-no-wrap">{{ $t(`theme.${currentThemeValue}`) }}</span>
+                  </v-btn>
+                </template>
+                <v-list density="compact" nav>
+                  <v-list-item
+                    v-for="th in themes"
+                    :key="th.value"
+                    @click="changeTheme(th.value)"
+                    :prepend-icon="th.icon"
+                    :active="isActiveTheme(th.value)"
+                  >
+                    <v-list-item-title>{{ $t(`theme.${th.value}`) }}</v-list-item-title>
+                  </v-list-item>
+                </v-list>
+              </v-menu>
+            </v-col>
+          </v-row>
+        </v-card-text>
+      </v-card>
+    </div>
   </template>
   
 <script lang="ts" setup>
-import { ref } from "vue"
+import { computed, ref } from "vue"
 import { useLocale } from 'vuetify'
 import { i18n, languages } from '@/locales'
 import { useRouter } from 'vue-router'
@@ -55,7 +65,7 @@ import HttpUtil from '@/plugins/httputil'
 import { useThemeSwitcher } from '@/composables/useThemeSwitcher'
 
 
-const locale = useLocale()
+const vuetifyLocale = useLocale()
 const { themes, changeTheme, isActiveTheme } = useThemeSwitcher()
 
 const username = ref('')
@@ -77,6 +87,16 @@ const passwordRules = [
 const loading = ref(false)
 const router = useRouter()
 
+const currentLanguageTitle = computed(() =>
+  languages.find(l => l.value === i18n.global.locale.value)?.title ?? 'English'
+)
+const currentThemeValue = computed(() => localStorage.getItem('theme') ?? 'system')
+const currentThemeIcon = computed(() =>
+  themes.find(t => t.value === currentThemeValue.value)?.icon ?? 'mdi-laptop'
+)
+
+const isActiveLocale = (l: string) => i18n.global.locale.value === l
+
 const login = async () => {
   if (username.value == '' || password.value == '') return
   loading.value=true
@@ -90,9 +110,28 @@ const login = async () => {
     loading.value=false
   }
 }
-const changeLocale = (l: any) => {
-  locale.current.value = l ?? 'en'
-  localStorage.setItem('locale', locale.current.value)
+const changeLocale = (l: string) => {
+  const v = (l ?? 'en') as typeof i18n.global.locale.value
+  i18n.global.locale.value = v
+  vuetifyLocale.current.value = v
+  localStorage.setItem('locale', l ?? 'en')
+  window.location.reload()
 }
 </script>
+
+<style scoped>
+.login-wrap {
+  min-height: 100vh;
+  min-height: 100dvh;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 24px;
+  box-sizing: border-box;
+}
+.login-card {
+  width: 100%;
+  max-width: 460px;
+}
+</style>
   

--- a/src/views/Outbounds.vue
+++ b/src/views/Outbounds.vue
@@ -42,8 +42,8 @@
   </v-row>
   <v-row>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>outbounds" :key="item.tag">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.tag">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.tag">
+        <v-card-subtitle>
           <v-row>
             <v-col>{{ item.type }}</v-col>
           </v-row>
@@ -113,12 +113,12 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showModal(item.id)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delOverlay[index] = true">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>

--- a/src/views/Rules.vue
+++ b/src/views/Rules.vue
@@ -39,8 +39,8 @@
   />
   <v-row>
     <v-col cols="12" justify="center" align="center">
-      <v-btn color="primary" @click="showRuleModal(-1)" style="margin: 0 5px;">{{ $t('rule.add') }}</v-btn>
-      <v-btn color="primary" @click="showRulesetModal(-1)" style="margin: 0 5px;">{{ $t('ruleset.add') }}</v-btn>
+      <v-btn color="primary" @click="showRuleModal(-1)" class="mx-1">{{ $t('rule.add') }}</v-btn>
+      <v-btn color="primary" @click="showRulesetModal(-1)" class="mx-1">{{ $t('ruleset.add') }}</v-btn>
       <v-menu v-model="actionMenu" :close-on-content-click="false" location="bottom center">
         <template v-slot:activator="{ props }">
           <v-btn v-bind="props" hide-details variant="text" icon>
@@ -68,7 +68,7 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col class="v-card-subtitle" cols="12">{{ $t('basic.routing.title') }}</v-col>
+    <v-col class="text-subtitle-2 text-medium-emphasis mt-2" cols="12">{{ $t('basic.routing.title') }}</v-col>
     <v-col cols="12">
       <v-row>
         <v-col cols="12" sm="6" md="3" lg="2">
@@ -89,10 +89,10 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col class="v-card-subtitle" cols="12">{{ $t('rule.ruleset') }}</v-col>
+    <v-col class="text-subtitle-2 text-medium-emphasis mt-2" cols="12">{{ $t('rule.ruleset') }}</v-col>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>rulesets" :key="item.tag">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.tag">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.tag">
+        <v-card-subtitle>
           <v-row><v-col>{{ $t('ruleset.' + item.type) }}</v-col></v-row>
         </v-card-subtitle>
         <v-card-text>
@@ -101,11 +101,11 @@
           <v-row><v-col>{{ $t('actions.update') }}</v-col><v-col>{{ item.update_interval ?? '-' }}</v-col></v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showRulesetModal(index)">
             <v-icon /><v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delRulesetOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delRulesetOverlay[index] = true">
             <v-icon /><v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>
           <v-overlay v-model="delRulesetOverlay[index]" contained class="align-center justify-center">
@@ -123,12 +123,12 @@
     </v-col>
   </v-row>
   <v-row>
-    <v-col class="v-card-subtitle" cols="12">{{ $t('pages.rules') }}</v-col>
+    <v-col class="text-subtitle-2 text-medium-emphasis mt-2" cols="12">{{ $t('pages.rules') }}</v-col>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>rules"
         :key="item.id" :draggable="true"
         @dragstart="onDragStart(index)" @dragover.prevent @drop="onDrop(index)">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="index+1">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="index+1">
+        <v-card-subtitle>
           <v-row><v-col>{{ item.type != undefined ? $t('rule.logical') + ' (' + item.mode + ')' : $t('rule.simple') }}</v-col></v-row>
         </v-card-subtitle>
         <v-card-text>
@@ -138,11 +138,11 @@
           <v-row><v-col>{{ $t('rule.invert') }}</v-col><v-col>{{ $t((item.invert ?? false) ? 'yes' : 'no') }}</v-col></v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showRuleModal(index)">
             <v-icon /><v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delRuleOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delRuleOverlay[index] = true">
             <v-icon /><v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>
           <v-overlay v-model="delRuleOverlay[index]" contained class="align-center justify-center">

--- a/src/views/Services.vue
+++ b/src/views/Services.vue
@@ -17,8 +17,8 @@
   </v-row>
   <v-row>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>services" :key="item.tag">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.tag">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.tag">
+        <v-card-subtitle>
           <v-row>
             <v-col>{{ item.type }}</v-col>
           </v-row>
@@ -44,12 +44,12 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showModal(item.id)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delOverlay[index] = true">
+          <v-btn icon="mdi-file-remove" class="ms-0" color="warning" @click="delOverlay[index] = true">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>

--- a/src/views/Settings.vue
+++ b/src/views/Settings.vue
@@ -12,7 +12,7 @@
     <v-tab value="t4">{{ $t('setting.clashSub') }}</v-tab>
   </v-tabs>
   <v-card-text>
-    <v-row align="center" justify="center" style="margin-bottom: 10px;">
+    <v-row align="center" justify="center">
       <v-col cols="auto">
         <v-btn color="primary" @click="save" :loading="loading" :disabled="!stateChange">
           {{ $t('actions.save') }}

--- a/src/views/Tls.vue
+++ b/src/views/Tls.vue
@@ -14,8 +14,8 @@
   </v-row>
   <v-row>
     <v-col cols="12" sm="4" md="3" lg="2" v-for="(item, index) in <any[]>tlsConfigs" :key="item.id">
-      <v-card rounded="xl" elevation="5" min-width="200" :title="item.name">
-        <v-card-subtitle style="margin-top: -15px;">
+      <v-card min-width="200" :title="item.name">
+        <v-card-subtitle>
           {{ item.server?.server_name?.length>0 ? item.server.server_name : "-" }}
         </v-card-subtitle>
         <v-card-text>
@@ -51,12 +51,12 @@
           </v-row>
         </v-card-text>
         <v-divider></v-divider>
-        <v-card-actions style="padding: 0;">
+        <v-card-actions class="px-2 py-1">
           <v-btn icon="mdi-file-edit" @click="showModal(item.id)">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.edit')"></v-tooltip>
           </v-btn>
-          <v-btn v-if="tlsInbounds(item.id).length == 0" icon="mdi-file-remove" style="margin-inline-start:0;" color="warning" @click="delOverlay[index] = true">
+          <v-btn v-if="tlsInbounds(item.id).length == 0" icon="mdi-file-remove" class="ms-0" color="warning" @click="delOverlay[index] = true">
             <v-icon />
             <v-tooltip activator="parent" location="top" :text="$t('actions.del')"></v-tooltip>
           </v-btn>


### PR DESCRIPTION
@alireza0 

## Before: 
Overly card-heavy design with a sense of multiple nesting, inconsistent spacing, and default scrollbars that felt visually jarring.

## After: 
A unified flat layout that eliminates the nested feel, standardizes spacing throughout, and seamlessly integrates scrollbars into the overall page design.

No functional changes were made — UI styling improvements only.

---

Both light and dark themes, as well as the mobile layout, have been tested and are functioning as expected.

---

### Updated UI preview

<img width="900" alt="0" src="https://github.com/user-attachments/assets/4d74d4fa-678b-4b50-beda-789f13907846" />

<img width="900" alt="1" src="https://github.com/user-attachments/assets/f6f79349-6e66-4ecd-9aa9-d3c69e042dac" />

<img width="900" alt="2" src="https://github.com/user-attachments/assets/fdc885be-6c82-4d3d-9ffe-730dc7581651" />

<img width="900" alt="3" src="https://github.com/user-attachments/assets/bce36d8d-c544-4787-bcad-4cbc91f4e717" />

<img width="900" alt="4" src="https://github.com/user-attachments/assets/a57b4c1b-5aa6-48cc-8013-026771b5daaa" />

<img width="900" alt="5" src="https://github.com/user-attachments/assets/6d7dbbbf-d21d-4730-8d0c-10c97996303c" />
