### PR TITLE
fix: SS plugin UI, Hysteria port-hopping, VLESS inbound flow gate

### DIFF
--- a/src/components/OutJson.vue
+++ b/src/components/OutJson.vue
@@ -30,6 +30,9 @@
           v-model="packet_encoding">
         </v-select>
       </v-col>
+      <v-col cols="12" sm="6" md="4" v-if="type == inTypes.VLESS">
+        <v-switch v-model="inData.out_json.allow_flow" color="primary" :label="$t('types.vless.flow')" hide-details></v-switch>
+      </v-col>
       <template v-if="type == inTypes.VMess">
         <v-col cols="12" sm="6" md="4">
           <v-select

--- a/src/components/protocols/Hysteria.vue
+++ b/src/components/protocols/Hysteria.vue
@@ -45,6 +45,23 @@
         <v-switch v-model="data.disable_mtu_discovery" color="primary" label="Disable MTU discovery" hide-details></v-switch>
       </v-col>
     </v-row>
+    <v-row v-if="direction=='out'">
+      <v-col cols="12" sm="8" v-if="optionMPort">
+        <v-text-field
+          :label="$t('rule.portRange') + ' ' + $t('commaSeparated')"
+          v-model="server_ports">
+        </v-text-field>
+      </v-col>
+      <v-col cols="12" sm="6" md="4" v-if="optionMPort">
+        <v-text-field
+          label="Hop interval"
+          type="number"
+          min="0"
+          :suffix="$t('date.s')"
+          v-model.number="hop_interval">
+        </v-text-field>
+      </v-col>
+    </v-row>
     <v-row>
       <v-col cols="12" sm="6" md="4" v-if="data.recv_window_conn != undefined">
         <v-text-field
@@ -91,6 +108,9 @@
         </template>
         <v-card>
           <v-list>
+            <v-list-item v-if="direction=='out'">
+              <v-switch v-model="optionMPort" color="primary" :label="$t('rule.portRange')" hide-details></v-switch>
+            </v-list-item>
             <v-list-item>
               <v-switch v-model="optionRsvConn" color="primary" label="Recv window conn" hide-details></v-switch>
             </v-list-item>
@@ -124,6 +144,18 @@ export default {
     optionRsvConn: {
       get(): boolean { return this.$props.data.recv_window_conn != undefined },
       set(v:boolean) { this.$props.data.recv_window_conn = v ? 15728640 : undefined }
+    },
+    optionMPort: {
+      get(): boolean { return this.$props.data.server_ports != undefined },
+      set(v:boolean) { this.$props.data.server_ports = v ? [] : undefined }
+    },
+    server_ports: {
+      get() { return this.$props.data.server_ports?.join(',') ?? '' },
+      set(v:string) { this.$props.data.server_ports = v.length > 0 ? v.split(',').map((s:string) => s.trim()) : undefined }
+    },
+    hop_interval: {
+      get() { return this.$props.data.hop_interval ? parseInt(this.$props.data.hop_interval.replace('s','')) : 0 },
+      set(v:number) { this.$props.data.hop_interval = v > 0 ? v + 's' : undefined }
     },
     optionRsvWin: {
       get(): boolean { return this.$props.data.recv_window != undefined },

--- a/src/components/protocols/Shadowsocks.vue
+++ b/src/components/protocols/Shadowsocks.vue
@@ -36,6 +36,14 @@
         </v-text-field>
       </v-col>
     </v-row>
+    <v-row v-if="direction == 'out'">
+      <v-col cols="12" sm="6" md="4">
+        <v-text-field label="Plugin" hide-details v-model="data.plugin" clearable></v-text-field>
+      </v-col>
+      <v-col cols="12" sm="8" v-if="data.plugin">
+        <v-text-field label="Plugin Options" hide-details v-model="data.plugin_opts"></v-text-field>
+      </v-col>
+    </v-row>
   </v-card>
 </template>
 

--- a/src/layouts/modals/Client.vue
+++ b/src/layouts/modals/Client.vue
@@ -147,12 +147,13 @@
                     v-model="clientConfig[key].uuid"
                     hide-details>
                   </v-text-field>
-                  <v-text-field
+                  <v-select
                     v-if="key == 'vless'"
-                    label="Flow"
+                    :label="$t('types.vless.flow')"
+                    :items="['','xtls-rprx-vision']"
                     v-model="clientConfig[key].flow"
                     hide-details>
-                  </v-text-field>
+                  </v-select>
                   <v-text-field
                     v-if="key == 'hysteria'"
                     label="Auth"

--- a/src/types/outbounds.ts
+++ b/src/types/outbounds.ts
@@ -78,6 +78,8 @@ export interface Shadowsocks extends OutboundBasics, Dial {
     version?: number
   }
   multiplex?: oMultiplex
+  plugin?: string
+  plugin_opts?: string
 }
 
 export interface VMESS extends OutboundBasics, Dial {
@@ -121,6 +123,8 @@ export interface Naive extends OutboundBasics, Dial {
 export interface Hysteria extends OutboundBasics, Dial {
   server: string
   server_port: number
+  server_ports?: string[]
+  hop_interval?: string
   up_mbps: number
   down_mbps: number
   obfs?: string


### PR DESCRIPTION
## Summary

- **SS plugin UI** (`Shadowsocks.vue`): Added `plugin` and `plugin_opts` text fields shown only in outbound direction. Fields are stored in `out_json` and emitted in share links by the backend.
- **Hysteria port-hopping UI** (`Hysteria.vue`, `OutJson.vue`): Added `server_ports` (comma-separated port ranges) and `hop_interval` fields stored in `out_json`. Rendered in the inbound settings advanced panel.
- **VLESS client flow selector** (`Client.vue`): Changed flow from a free-text field to a `v-select` with `["", "xtls-rprx-vision"]` so users pick a valid value.
- **VLESS inbound-level flow gate** (`OutJson.vue`): Added `allow_flow` boolean switch in the inbound output settings panel. Controls whether client flow is emitted at all for this inbound. Backend (`vlessOut`) auto-defaults to `true` when reality TLS is detected.
- **Type definitions** (`outbounds.ts`): Added `plugin?`, `plugin_opts?` to `Shadowsocks`; `server_ports?`, `hop_interval?` to `Hysteria`.

## Flow gate behavior

- Inbound `allow_flow = false` (or absent) → no flow in any share link / sub JSON for that inbound, regardless of client config
- Inbound `allow_flow = true` + client has flow → flow emitted
- Inbound `allow_flow = true` + client has no flow → no flow emitted
- Reality TLS inbounds default to `allow_flow = true` automatically

Companion backend PR: https://github.com/alireza0/s-ui/pull/1194

## Test plan

- [ ] SS inbound with plugin configured → share link contains `?plugin=name%3Bopts`
- [ ] Hysteria inbound with port ranges → JSON sub includes `server_ports` array
- [ ] VLESS client flow dropdown only allows blank or `xtls-rprx-vision`
- [ ] VLESS reality inbound: flow gate defaults ON; share link and JSON sub emit client flow
- [ ] Toggle flow gate OFF → share link and JSON sub drop flow field

🤖 Generated with [Claude Code](https://claude.com/claude-code)